### PR TITLE
Automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
                         - name: Compile driver
                           shell: bash
                           run: |
+                                  #debug:
+                                  echo "DEBUG:"
+                                  find / -name *linux-headers* 2>/dev/null;
                                   # run dkms build and all available kernel headers
                                   failed=""
                                   succeeded=""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,11 @@ jobs:
                           shell: bash
                           run: |
                                 # latest generic and oem kernel headers
-                                sudo apt install linux-headers-generic linux-headers-oem
+                                # too old, still 5.4 - sudo apt install linux-headers-generic
+                                sudo apt install linux-headers-oem-20.04
                                 # wip kernel headers
                                 sudo add-apt-repository ppa:canonical-kernel-team/unstable
+                                sudo apt update
                                 sudo apt install linux-headers-generic-wip
 
                         - name: Patch build scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
                           shell: bash
                           run: |
                                   # latest generic kernel headers - once we move to 22.04
-                                  # sudo apt install linux-headers-generic
+                                  # sudo apt install --yes linux-headers-generic
                                   # latest oem kernel
-                                  sudo apt install linux-headers-oem-20.04
+                                  sudo apt install --yes linux-headers-oem-20.04
                                   # wip kernel headers - once we move to 22.04
                                   # sudo add-apt-repository ppa:canonical-kernel-team/unstable
                                   # sudo apt update
-                                  # sudo apt install linux-headers-generic-wip
+                                  # sudo apt install --yes linux-headers-generic-wip
 
                         - name: Patch build scripts
                           shell: bash
@@ -58,16 +58,19 @@ jobs:
                                         ret=$(dkms build -m ipu6-drivers/0.0.0 -k ${kver} >&2; echo $?);
                                         if [ ${ret} -eq 0 ]; then
                                                 succeeded="${succeeded} ${kver}"
-                                                #modinfo v4l2loopback.ko;
+                                                echo "debug: find where the module is built";
+                                                find / -name intel-ipu6.ko 2>/dev/null;
+                                                #echo "modinfo";
+                                                #modinfo -k ${kver} intel-ipu6;
                                         else
                                                 echo "#### Skipped unexpected failure ${kver}";
                                                 failed="${failed} ${kver}";
                                         fi;
                                         #make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
-                                done
-                                if [ "x${failed}" != "x" ]; then
+                                  done
+                                  if [ "x${failed}" != "x" ]; then
                                         echo "#### Failed kernels: ${failed}";
                                         exit 1
-                                fi
-                                echo "#### Successful builds for kernels: ${succeeded}";
+                                  fi
+                                  echo "#### Successful builds for kernels: ${succeeded}";
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
                                         # are preinstalled and it seems we can't build for it
                                         if [[ "$kver" == *"azure"* ]]; then
                                                 echo "Skipping $kver - This is the kernel of the github runner.";
-                                                break;
+                                                continue;
                                         fi;
                                         test -d $kver || continue
                                         kver=${kver%/build}
@@ -68,15 +68,10 @@ jobs:
                                         ret=$(dkms build -m ipu6-drivers/0.0.0 -k ${kver} >&2; echo $?);
                                         if [ ${ret} -eq 0 ]; then
                                                 succeeded="${succeeded} ${kver}"
-                                                echo "debug: find where the module is built";
-                                                find / -name intel-ipu6.ko 2>/dev/null;
-                                                #echo "modinfo";
-                                                #modinfo -k ${kver} intel-ipu6;
                                         else
                                                 echo "#### Skipped unexpected failure ${kver}";
                                                 failed="${failed} ${kver}";
                                         fi;
-                                        #make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
                                   done
                                   if [ "x${failed}" != "x" ]; then
                                         echo "#### Failed kernels: ${failed}";

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,8 @@ jobs:
                           run: |
                                   #debug:
                                   echo "DEBUG:"
-                                  find / -name *linux-headers* 2>/dev/null;
+                                  echo "ls /usr/src"; ls /usr/src;
+                                  echo "ls /lib/modules"; ls /lib/modules;
                                   # run dkms build and all available kernel headers
                                   failed=""
                                   succeeded=""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,12 @@ jobs:
                                   failed=""
                                   succeeded=""
                                   for kver in /lib/modules/*/build; do
+                                        # skip the kernel headers from the azure kernel. These kernel headers
+                                        # are preinstalled and it seems we can't build for it
+                                        if [[ "$kver" == *"azure"* ]]; then
+                                                echo "Skipping $kver - This is the kernel of the github runner.";
+                                                break;
+                                        fi;
                                         test -d $kver || continue
                                         kver=${kver%/build}
                                         kver=${kver##*/}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+on: [push, pull_request]
+#schedule:
+#       - cron: '30 1 * * *' #every day at 1:30am
+jobs:
+        test-dkms:
+                # ubuntu-lastest is currently still 20.04
+                runs-on: ubuntu-latest
+                steps:
+                        - name: Checkout
+                          uses: actions/checkout@v3
+
+                        - name: Prepare environment
+                          shell: bash
+                          run: |
+                                sudo apt-get update --quiet;
+                                sudo apt-get install --yes --no-install-recommends dkms kmod
+
+                        - name: Download header files
+                          shell: bash
+                          run: |
+                                # latest generic and oem kernel headers
+                                sudo apt install linux-headers-generic linux-headers-oem
+                                # wip kernel headers
+                                sudo add-apt-repository ppa:canonical-kernel-team/unstable
+                                sudo apt install linux-headers-generic-wip
+
+                        - name: Patch build scripts
+                          shell: bash
+                          run: |
+                                # there is a dependency on the ivsc modules that prevents building the sensor drivers
+                                # remove sensors from the dkms file
+                                sed -i '/\[[4,5,6,7]\]/d' dkms.conf
+                                # disable sensor modules in the Makefile
+                                sed -i 's/export CONFIG_VIDEO_OV/#export CONFIG_VIDEO_OV/g' Makefile
+                                sed -i 's/export CONFIG_VIDEO_HM/#export CONFIG_VIDEO_HM/g' Makefile
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
                                         kver=${kver##*/}
                                         echo "=== Testing ${kver} ===";
                                         echo "running: dkms build -m ipu6-drivers/0.0.0 -k ${kver}";
-                                        ret=$(dkms build -m ipu6-drivers/0.0.0 -k ${kver} >&2; echo $?);
+                                        ret=$(sudo dkms build -m ipu6-drivers/0.0.0 -k ${kver} >&2; echo $?);
                                         if [ ${ret} -eq 0 ]; then
                                                 succeeded="${succeeded} ${kver}"
                                         else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,27 +13,61 @@ jobs:
                         - name: Prepare environment
                           shell: bash
                           run: |
-                                sudo apt-get update --quiet;
-                                sudo apt-get install --yes --no-install-recommends dkms kmod
+                                  sudo apt-get update --quiet;
+                                  sudo apt-get install --yes --no-install-recommends dkms kmod
 
                         - name: Download header files
                           shell: bash
                           run: |
-                                # latest generic and oem kernel headers
-                                # too old, still 5.4 - sudo apt install linux-headers-generic
-                                sudo apt install linux-headers-oem-20.04
-                                # wip kernel headers
-                                sudo add-apt-repository ppa:canonical-kernel-team/unstable
-                                sudo apt update
-                                sudo apt install linux-headers-generic-wip
+                                  # latest generic kernel headers - once we move to 22.04
+                                  # sudo apt install linux-headers-generic
+                                  # latest oem kernel
+                                  sudo apt install linux-headers-oem-20.04
+                                  # wip kernel headers - once we move to 22.04
+                                  # sudo add-apt-repository ppa:canonical-kernel-team/unstable
+                                  # sudo apt update
+                                  # sudo apt install linux-headers-generic-wip
 
                         - name: Patch build scripts
                           shell: bash
                           run: |
-                                # there is a dependency on the ivsc modules that prevents building the sensor drivers
-                                # remove sensors from the dkms file
-                                sed -i '/\[[4,5,6,7]\]/d' dkms.conf
-                                # disable sensor modules in the Makefile
-                                sed -i 's/export CONFIG_VIDEO_OV/#export CONFIG_VIDEO_OV/g' Makefile
-                                sed -i 's/export CONFIG_VIDEO_HM/#export CONFIG_VIDEO_HM/g' Makefile
+                                  # there is a dependency on the ivsc modules that prevents building the sensor drivers
+                                  # remove sensors from the dkms file
+                                  sed -i '/\[[4,5,6,7]\]/d' dkms.conf
+                                  # disable sensor modules in the Makefile
+                                  sed -i 's/export CONFIG_VIDEO_OV/#export CONFIG_VIDEO_OV/g' Makefile
+                                  sed -i 's/export CONFIG_VIDEO_HM/#export CONFIG_VIDEO_HM/g' Makefile
+
+                        - name: Register w/ dkms
+                          shell: bash
+                          run: |
+                                  sudo dkms add .
+
+                        - name: Compile driver
+                          shell: bash
+                          run: |
+                                  # run dkms build and all available kernel headers
+                                  failed=""
+                                  succeeded=""
+                                  for kver in /lib/modules/*/build; do
+                                        test -d $kver || continue
+                                        kver=${kver%/build}
+                                        kver=${kver##*/}
+                                        echo "=== Testing ${kver} ===";
+                                        echo "running: dkms build -m ipu6-drivers/0.0.0 -k ${kver}";
+                                        ret=$(dkms build -m ipu6-drivers/0.0.0 -k ${kver} >&2; echo $?);
+                                        if [ ${ret} -eq 0 ]; then
+                                                succeeded="${succeeded} ${kver}"
+                                                #modinfo v4l2loopback.ko;
+                                        else
+                                                echo "#### Skipped unexpected failure ${kver}";
+                                                failed="${failed} ${kver}";
+                                        fi;
+                                        #make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
+                                done
+                                if [ "x${failed}" != "x" ]; then
+                                        echo "#### Failed kernels: ${failed}";
+                                        exit 1
+                                fi
+                                echo "#### Successful builds for kernels: ${succeeded}";
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
                                   # sudo apt install --yes linux-headers-generic
                                   # latest oem kernel
                                   sudo apt install --yes linux-headers-oem-20.04
+                                  # sudo apt install --yes linux-headers-oem-22.04
                                   # wip kernel headers - once we move to 22.04
                                   # sudo add-apt-repository ppa:canonical-kernel-team/unstable
                                   # sudo apt update
@@ -46,16 +47,12 @@ jobs:
                         - name: Compile driver
                           shell: bash
                           run: |
-                                  #debug:
-                                  echo "DEBUG:"
-                                  echo "ls /usr/src"; ls /usr/src;
-                                  echo "ls /lib/modules"; ls /lib/modules;
                                   # run dkms build and all available kernel headers
                                   failed=""
                                   succeeded=""
                                   for kver in /lib/modules/*/build; do
                                         # skip the kernel headers from the azure kernel. These kernel headers
-                                        # are preinstalled and it seems we can't build for it
+                                        # are preinstalled and of no interest
                                         if [[ "$kver" == *"azure"* ]]; then
                                                 echo "Skipping $kver - This is the kernel of the github runner.";
                                                 continue;


### PR DESCRIPTION
Github action for building dkms against Ubuntu kernel.
Github runners are still on 20.04, so we only build for one kernel initially. Once we switch to 22.04 we can add more kernels.