### PR TITLE
Ipu6 probe ordering fixes

### DIFF
--- a/drivers/media/pci/intel/Makefile
+++ b/drivers/media/pci/intel/Makefile
@@ -7,6 +7,7 @@ subdir-ccflags-y := -Wall -Wextra
 subdir-ccflags-y += $(call cc-disable-warning, unused-parameter)
 subdir-ccflags-y += $(call cc-disable-warning, implicit-fallthrough)
 subdir-ccflags-y += $(call cc-disable-warning, missing-field-initializers)
+subdir-ccflags-y += $(call cc-disable-warning, type-limits)
 subdir-ccflags-$(CONFIG_VIDEO_INTEL_IPU_WERROR) += -Werror
 
 obj-$(CONFIG_VIDEO_INTEL_IPU6)	+= ipu6/

--- a/drivers/media/pci/intel/ipu-bus.c
+++ b/drivers/media/pci/intel/ipu-bus.c
@@ -149,6 +149,9 @@ static struct mutex ipu_bus_mutex;
 
 static void ipu_bus_release(struct device *dev)
 {
+	struct ipu_bus_device *adev = to_ipu_bus_device(dev);
+
+	kfree(adev);
 }
 
 struct ipu_bus_device *ipu_bus_initialize_device(struct pci_dev *pdev,
@@ -159,7 +162,7 @@ struct ipu_bus_device *ipu_bus_initialize_device(struct pci_dev *pdev,
 	struct ipu_bus_device *adev;
 	struct ipu_device *isp = pci_get_drvdata(pdev);
 
-	adev = devm_kzalloc(&pdev->dev, sizeof(*adev), GFP_KERNEL);
+	adev = kzalloc(sizeof(*adev), GFP_KERNEL);
 	if (!adev)
 		return ERR_PTR(-ENOMEM);
 

--- a/drivers/media/pci/intel/ipu-bus.h
+++ b/drivers/media/pci/intel/ipu-bus.h
@@ -43,10 +43,11 @@ struct ipu_bus_driver {
 
 #define to_ipu_bus_driver(_drv) container_of(_drv, struct ipu_bus_driver, drv)
 
-struct ipu_bus_device *ipu_bus_add_device(struct pci_dev *pdev,
-					  struct device *parent, void *pdata,
-					  struct ipu_buttress_ctrl *ctrl,
-					  char *name, unsigned int nr);
+struct ipu_bus_device *ipu_bus_initialize_device(struct pci_dev *pdev,
+						 struct device *parent, void *pdata,
+						 struct ipu_buttress_ctrl *ctrl,
+						 char *name, unsigned int nr);
+int ipu_bus_add_device(struct ipu_bus_device *adev);
 void ipu_bus_del_devices(struct pci_dev *pdev);
 
 int ipu_bus_register_driver(struct ipu_bus_driver *adrv);

--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -70,12 +70,14 @@ static struct ipu_bus_device *ipu_isys_init(struct pci_dev *pdev,
 		if (fwnode && !IS_ERR_OR_NULL(fwnode->secondary)) {
 			dev_err(&pdev->dev,
 				"fwnode graph has no endpoints connection\n");
-			return ERR_PTR(-ENOMEM);
+			return ERR_PTR(-EINVAL);
 		}
 
 		ret = ipu_isys_bridge_init(pdev);
-		if (ret)
-			return ERR_PTR(-ENOMEM);
+		if (ret) {
+			dev_err_probe(&pdev->dev, ret, "ipu_isys_bridge_init() failed\n");
+			return ERR_PTR(ret);
+		}
 	}
 #endif
 
@@ -92,13 +94,17 @@ static struct ipu_bus_device *ipu_isys_init(struct pci_dev *pdev,
 
 	isys = ipu_bus_add_device(pdev, parent, pdata, ctrl,
 				  IPU_ISYS_NAME, nr);
-	if (IS_ERR(isys))
-		return ERR_PTR(-ENOMEM);
+	if (IS_ERR(isys)) {
+		dev_err_probe(&pdev->dev, PTR_ERR(isys), "ipu_bus_add_device(isys) failed\n");
+		return ERR_CAST(isys);
+	}
 
 	isys->mmu = ipu_mmu_init(&pdev->dev, base, ISYS_MMID,
 				 &ipdata->hw_variant);
-	if (IS_ERR(isys->mmu))
-		return ERR_PTR(-ENOMEM);
+	if (IS_ERR(isys->mmu)) {
+		dev_err_probe(&pdev->dev, PTR_ERR(isys), "ipu_mmu_init(isys->mmu) failed\n");
+		return ERR_CAST(isys->mmu);
+	}
 
 	isys->mmu->dev = &isys->dev;
 
@@ -124,13 +130,17 @@ static struct ipu_bus_device *ipu_psys_init(struct pci_dev *pdev,
 
 	psys = ipu_bus_add_device(pdev, parent, pdata, ctrl,
 				  IPU_PSYS_NAME, nr);
-	if (IS_ERR(psys))
-		return ERR_PTR(-ENOMEM);
+	if (IS_ERR(psys)) {
+		dev_err_probe(&pdev->dev, PTR_ERR(psys), "ipu_bus_add_device(psys) failed\n");
+		return ERR_CAST(psys);
+	}
 
 	psys->mmu = ipu_mmu_init(&pdev->dev, base, PSYS_MMID,
 				 &ipdata->hw_variant);
-	if (IS_ERR(psys->mmu))
-		return ERR_PTR(-ENOMEM);
+	if (IS_ERR(psys->mmu)) {
+		dev_err_probe(&pdev->dev, PTR_ERR(psys), "ipu_mmu_init(psys->mmu) failed\n");
+		return ERR_CAST(psys->mmu);
+	}
 
 	psys->mmu->dev = &psys->dev;
 

--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -565,6 +565,7 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				  0);
 	if (IS_ERR(isp->isys)) {
 		rval = PTR_ERR(isp->isys);
+		isp->isys = NULL;
 		goto out_ipu_bus_del_devices;
 	}
 
@@ -582,6 +583,7 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				  &psys_ipdata, 0);
 	if (IS_ERR(isp->psys)) {
 		rval = PTR_ERR(isp->psys);
+		isp->psys = NULL;
 		goto out_ipu_bus_del_devices;
 	}
 

--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -539,9 +539,6 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (rval)
 		dev_err(&pdev->dev, "Trace support not available\n");
 
-	pm_runtime_put_noidle(&pdev->dev);
-	pm_runtime_allow(&pdev->dev);
-
 	/*
 	 * NOTE Device hierarchy below is important to ensure proper
 	 * runtime suspend and resume order.
@@ -625,7 +622,6 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	}
 
 	ipu_mmu_hw_cleanup(isp->psys->mmu);
-	pm_runtime_put(&isp->psys->dev);
 
 #ifdef CONFIG_DEBUG_FS
 	rval = ipu_init_debugfs(isp);
@@ -644,6 +640,9 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		 IPU_MAJOR_VERSION,
 		 IPU_MINOR_VERSION);
 
+	pm_runtime_allow(&pdev->dev);
+	pm_runtime_put(&isp->psys->dev);
+	pm_runtime_put(&pdev->dev);
 	return 0;
 
 out_ipu_bus_del_devices:

--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -61,8 +61,8 @@ static struct ipu_bus_device *ipu_isys_init(struct pci_dev *pdev,
 {
 	struct ipu_bus_device *isys;
 	struct ipu_isys_pdata *pdata;
-#if defined(CONFIG_IPU_ISYS_BRIDGE)
 	int ret;
+#if defined(CONFIG_IPU_ISYS_BRIDGE)
 	struct fwnode_handle *fwnode = dev_fwnode(&pdev->dev);
 
 	ret = ipu_isys_check_fwnode_graph(fwnode);
@@ -92,8 +92,7 @@ static struct ipu_bus_device *ipu_isys_init(struct pci_dev *pdev,
 	if (ipu_ver == IPU_VER_6SE)
 		ctrl->ratio = IPU6SE_IS_FREQ_CTL_DEFAULT_RATIO;
 
-	isys = ipu_bus_add_device(pdev, parent, pdata, ctrl,
-				  IPU_ISYS_NAME, nr);
+	isys = ipu_bus_initialize_device(pdev, parent, pdata, ctrl, IPU_ISYS_NAME, nr);
 	if (IS_ERR(isys)) {
 		dev_err_probe(&pdev->dev, PTR_ERR(isys), "ipu_bus_add_device(isys) failed\n");
 		return ERR_CAST(isys);
@@ -108,6 +107,10 @@ static struct ipu_bus_device *ipu_isys_init(struct pci_dev *pdev,
 
 	isys->mmu->dev = &isys->dev;
 
+	ret = ipu_bus_add_device(isys);
+	if (ret)
+		return ERR_PTR(ret);
+
 	return isys;
 }
 
@@ -120,6 +123,7 @@ static struct ipu_bus_device *ipu_psys_init(struct pci_dev *pdev,
 {
 	struct ipu_bus_device *psys;
 	struct ipu_psys_pdata *pdata;
+	int ret;
 
 	pdata = devm_kzalloc(&pdev->dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
@@ -128,8 +132,7 @@ static struct ipu_bus_device *ipu_psys_init(struct pci_dev *pdev,
 	pdata->base = base;
 	pdata->ipdata = ipdata;
 
-	psys = ipu_bus_add_device(pdev, parent, pdata, ctrl,
-				  IPU_PSYS_NAME, nr);
+	psys = ipu_bus_initialize_device(pdev, parent, pdata, ctrl, IPU_PSYS_NAME, nr);
 	if (IS_ERR(psys)) {
 		dev_err_probe(&pdev->dev, PTR_ERR(psys), "ipu_bus_add_device(psys) failed\n");
 		return ERR_CAST(psys);
@@ -143,6 +146,10 @@ static struct ipu_bus_device *ipu_psys_init(struct pci_dev *pdev,
 	}
 
 	psys->mmu->dev = &psys->dev;
+
+	ret = ipu_bus_add_device(psys);
+	if (ret)
+		return ERR_PTR(ret);
 
 	return psys;
 }


### PR DESCRIPTION
I have been working on making the ipu6-driver stack work on a Lenovo Thinkpad X1 Yoga gen 7 (alderlake) with a 6.0 kernel and using the INT3472 mainline kernel driver for power-control.

With the ipu6 code using acpi_dev_ready_for_enumeration() for kernel versions >= 5.17 ipu_psys_init() was returning -EPROBE_DEFER (and still does a number of time when letting udev automatically load the modules).

After fixing this I hit a bunch of other probe-ordering issues. This pull-req fixes all of these.

When combined with a matching pull-req for ivsc-drivers which I'm about to submit as well as [this](https://lore.kernel.org/linux-acpi/20221022150722.31787-1-hdegoede@redhat.com/) mainline kernel patch (+ the "standard" mainline patches) this results in a working camera on the Lenovo Thinkpad X1 Yoga gen 7 for me, with the modules autoloaded by udev and with the module load ordering not mattering.

Note before this patch-series there are a bunch of issues / NULL pointer dereferences when intel_ipu6_isys is already loaded by the time all the deps are ready (once we no longer get a -EPROBE_DEFER).

Cc: @mrhpearson, @vicamo , @cjechlitschek 