### PR TITLE
Fix crash due to ipu_psys_probe() dereferencing isp->pkg_dir before ipu_pci_probe() sets it

### DIFF
--- a/drivers/media/pci/intel/ipu-bus.c
+++ b/drivers/media/pci/intel/ipu-bus.c
@@ -15,6 +15,9 @@
 #include "ipu-platform.h"
 #include "ipu-dma.h"
 
+bool ipu_bus_ready_to_probe;
+EXPORT_SYMBOL(ipu_bus_ready_to_probe);
+
 #ifdef CONFIG_PM
 static struct bus_type ipu_bus;
 
@@ -90,6 +93,9 @@ static int ipu_bus_probe(struct device *dev)
 	struct ipu_bus_device *adev = to_ipu_bus_device(dev);
 	struct ipu_bus_driver *adrv = to_ipu_bus_driver(dev->driver);
 	int rval;
+
+	if (!ipu_bus_ready_to_probe)
+		return -EPROBE_DEFER;
 
 	dev_dbg(dev, "bus probe dev %s\n", dev_name(dev));
 

--- a/drivers/media/pci/intel/ipu-bus.h
+++ b/drivers/media/pci/intel/ipu-bus.h
@@ -12,6 +12,8 @@
 
 #define IPU_BUS_NAME	IPU_NAME "-bus"
 
+extern bool ipu_bus_ready_to_probe;
+
 struct ipu_buttress_ctrl;
 struct ipu_subsystem_trace_config;
 

--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -649,6 +649,7 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	pm_runtime_put_noidle(&pdev->dev);
 	pm_runtime_allow(&pdev->dev);
 
+	ipu_bus_ready_to_probe = true;
 	return 0;
 
 out_ipu_bus_del_devices:


### PR DESCRIPTION
This fixes a crash on a ThinkPad X1 Yoga Gen 7 in the following scenario (which happens every boot!):

1. intel-ipu6 gets loaded by udev based on its PCI modalias
2. ipu_pci_probe() exits with -EPROBE_DEFER because the int3472 driver for the power-ctrl has not loaded yet
3. intel-ipu6-isys + intel-ipu6-psys get loaded by udev based on the PCI modaliases they contain
4. intel-ipu6-isys + intel-ipu6-psys register their ipu_bus_driver-s with ipu_bus_register_driver()
5. ipu_pci_probe() exits with -EPROBE_DEFER a couple more times
6. udev loads the int3472 driver
7. ipu_pci_probe() no longer hits a path resulting -EPROBE_DEFER, instead it calls ipu_psys_init()
8. ipu_psys_init() calls ipu_bus_add_device(psys), which immediately causes the intel-ipu6-psys driver, which has already been registered, to bind
9. ipu_psys_probe() tries to defer isp->pkg_dir which has not been set yet. The problem is that ipu_pci_probe() sets isp->pkg_dir after calling ipu_psys_init().

And the dereference of the unset isp->pkg_dir then lead to:

```
 BUG: kernel NULL pointer dereference, address: 0000000000000008
 #PF: supervisor read access in kernel mode
 #PF: error_code(0x0000) - not-present page
 PGD 0 P4D 0
 Oops: 0000 [#1] PREEMPT SMP NOPTI
 CPU: 0 PID: 516 Comm: kworker/u32:4 Tainted: G           O       6.1.0-rc6+ #1
 Hardware name: LENOVO 21CEZ9Q3US/21CEZ9Q3US, BIOS N3AET66W (1.31 ) 09/09/2022
 Workqueue: events_unbound async_run_entry_fn
 RIP: 0010:ipu_cpd_pkg_dir_get_num_entries+0x5/0x10 [intel_ipu6]
 Code: 0f 1f 44 00 00 0f 1f 44 00 00 8d 44 36 02 48 98 8b 04 c7 c3 cc cc cc cc 66 66 2e 0f 1f 84 00 00 00 00 00 66 90 0f 1f 44 00 00 <8b> 47 08 c3 cc cc cc cc 0f 1f 00 0f 1f 44 00 00 8d 44 36 03 48 98
 RSP: 0018:ffffbd0c41b7fcb8 EFLAGS: 00010246
 RAX: ffff9dc50a6fe6b0 RBX: ffff9dc50ec4b800 RCX: 0000000000002000
 RDX: ffff9dc50a6fe6b0 RSI: ffff9dc50a6fe6b0 RDI: 0000000000000000
 RBP: ffffbd0c41b7fd28 R08: ffff9dc561ccf020 R09: ffffbd0c41c56000
 R10: ffff9dc50b468000 R11: 0000000068a6f580 R12: ffff9dc561ccf020
 R13: ffff9dc50a6fe028 R14: 0000000000000000 R15: 0000000000000000
 FS:  0000000000000000(0000) GS:ffff9dc83d400000(0000) knlGS:0000000000000000
 CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
 CR2: 0000000000000008 CR3: 0000000169076003 CR4: 0000000000770ef0
 PKRU: 55555554
 Call Trace:
  <TASK>
  ipu_psys_probe+0x384/0x6e0 [intel_ipu6_psys]
  ipu_bus_probe+0x44/0xd0 [intel_ipu6]
  really_probe+0xdb/0x380
  ...
```

Fixing this is non trivial:

We cannot simply set isp->pkg_dir before calling ipu_psys_init() because the ipu_buttress_map_fw_image() and ipu_cpd_create_pkg_dir() calls necessary for this require isp->psys which comes from ipu_psys_init(). So there is a circular dependency.

It seems there are various assumptions in the driver that the isys and psys modules will only be loaded after ipu_pci_probe() has completed successfully and thus that ipu_sys_probe() and ipu_psys_probe() will only run after ipu_pci_probe() has completed successfully.

Rather then chasing down all the issues caused by this, I have chosen to emulate this behavior by making ipu_bus_probe() return -EPROBE_DEFER until ipu_pci_probe() has completed.

An additional advantage of this is that the isys + psys probe functions will now run asynchronously speeding up the boot a bit.

Cc: @mrhpearson, @vicamo , @cjechlitschek
