### PR TITLE
Fix dmabuf errors with kernel 6.2

### DIFF
--- a/drivers/media/pci/intel/ipu-psys.c
+++ b/drivers/media/pci/intel/ipu-psys.c
@@ -622,7 +622,11 @@ static inline void ipu_psys_kbuf_unmap(struct ipu_psys_kbuffer *kbuf)
 		struct iosys_map dmap;
 
 		iosys_map_set_vaddr(&dmap, kbuf->kaddr);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+		dma_buf_vunmap_unlocked(kbuf->dbuf, &dmap);
+#else
 		dma_buf_vunmap(kbuf->dbuf, &dmap);
+#endif
 	}
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE != KERNEL_VERSION(5, 10, 46)
 	if (kbuf->kaddr) {
@@ -635,10 +639,17 @@ static inline void ipu_psys_kbuf_unmap(struct ipu_psys_kbuffer *kbuf)
 	if (kbuf->kaddr)
 		dma_buf_vunmap(kbuf->dbuf, kbuf->kaddr);
 #endif
-	if (kbuf->sgt)
+	if (kbuf->sgt) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+		dma_buf_unmap_attachment_unlocked(kbuf->db_attach,
+						  kbuf->sgt,
+						  DMA_BIDIRECTIONAL);
+#else
 		dma_buf_unmap_attachment(kbuf->db_attach,
 					 kbuf->sgt,
 					 DMA_BIDIRECTIONAL);
+#endif
+	}
 	if (kbuf->db_attach)
 		dma_buf_detach(kbuf->dbuf, kbuf->db_attach);
 	dma_buf_put(kbuf->dbuf);
@@ -828,7 +839,11 @@ int ipu_psys_mapbuf_locked(int fd, struct ipu_psys_fh *fh,
 		goto kbuf_map_fail;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+	kbuf->sgt = dma_buf_map_attachment_unlocked(kbuf->db_attach, DMA_BIDIRECTIONAL);
+#else
 	kbuf->sgt = dma_buf_map_attachment(kbuf->db_attach, DMA_BIDIRECTIONAL);
+#endif
 	if (IS_ERR_OR_NULL(kbuf->sgt)) {
 		ret = -EINVAL;
 		kbuf->sgt = NULL;
@@ -839,7 +854,11 @@ int ipu_psys_mapbuf_locked(int fd, struct ipu_psys_fh *fh,
 	kbuf->dma_addr = sg_dma_address(kbuf->sgt->sgl);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE != KERNEL_VERSION(5, 10, 46)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+	ret = dma_buf_vmap_unlocked(kbuf->dbuf, &dmap);
+#else
 	ret = dma_buf_vmap(kbuf->dbuf, &dmap);
+#endif
 	if (ret) {
 		dev_dbg(&psys->adev->dev, "dma buf vmap failed\n");
 		goto kbuf_map_fail;


### PR DESCRIPTION
Linux kernels >= 6.2 need drivers to either explicitly take the dma-buf-reservation lock themselves; or they need to call the _unlocked variant of various dmabuf functions to do this for them.

See upstream linux commit ae2e7f28a170c01f ("dma-buf: Document dynamic locking convention") for details.

This fixes the following crashes with 6.2:

```
[ 2038.884232] ------------[ cut here ]------------
[ 2038.884240] WARNING: CPU: 6 PID: 5873 at drivers/dma-buf/dma-buf.c:1120 dma_buf_map_attachment+0x92/0x120
[ 2038.884246] Modules linked in: snd_seq_dummy snd_hrtimer qrtr bnep binfmt_misc snd_ctl_led snd_soc_skl_hda_dsp snd_soc_intel_hda_dsp_common snd_sof_probes snd_soc_hdac_hdmi snd_soc_dmic iTCO_wdt intel_pmc_bxt iTCO_vendor_support mei_pxp mei_hdcp gpio_ljca(O) spi_ljca(O) i2c_ljca(O) pmt_telemetry pmt_class intel_rapl_msr intel_tcc_cooling x86_pkg_temp_thermal intel_powerclamp coretemp kvm_intel kvm irqbypass rapl intel_cstate intel_uncore pcspkr think_lmi firmware_attributes_class wmi_bmof snd_hda_codec_hdmi snd_hda_codec_realtek snd_hda_codec_generic snd_sof_pci_intel_tgl snd_sof_intel_hda_common soundwire_intel soundwire_generic_allocation soundwire_cadence snd_sof_intel_hda snd_sof_pci snd_sof_xtensa_dsp snd_sof snd_sof_utils snd_soc_hdac_hda snd_hda_ext_core snd_soc_acpi_intel_match snd_soc_acpi soundwire_bus iwlmvm snd_soc_core snd_compress ac97_bus snd_pcm_dmaengine snd_hda_intel mac80211 snd_intel_dspcfg snd_intel_sdw_acpi snd_hda_codec snd_hda_core snd_hwdep libarc4 snd_seq
[ 2038.884294]  snd_seq_device btusb snd_pcm btrtl btbcm iwlwifi btintel i2c_i801 snd_timer i2c_smbus btmtk iosm bluetooth mei_me idma64 intel_ipu6_isys(O) ljca(O) ecdh_generic videobuf2_dma_contig joydev hid_sensor_gyro_3d cfg80211 videobuf2_memops videobuf2_v4l2 hid_sensor_accel_3d hid_sensor_trigger videobuf2_common hid_sensor_iio_common industrialio_triggered_buffer kfifo_buf intel_ipu6_psys(O) industrialio thunderbolt intel_vsec processor_thermal_device_pci processor_thermal_device processor_thermal_rfim processor_thermal_mbox intel_ipu6(O) processor_thermal_rapl intel_rapl_common igen6_edac mei_vsc(O) mei int3403_thermal int340x_thermal_zone soc_button_array ov2740(O) v4l2_fwnode v4l2_async videodev intel_skl_int3472_tps68470 tps68470_regulator clk_tps68470 mc intel_skl_int3472_discrete intel_hid sparse_keymap int3400_thermal acpi_thermal_rel acpi_tad acpi_pad vfat fat zram dm_crypt hid_sensor_hub intel_ishtp_hid i915 thinkpad_acpi crct10dif_pclmul drm_buddy snd crc32_pclmul
[ 2038.884344]  soundcore drm_display_helper crc32c_intel ledtrig_audio platform_profile rfkill nvme intel_ish_ipc cec ucsi_acpi ghash_clmulni_intel wacom hid_multitouch sha512_ssse3 serio_raw typec_ucsi video intel_ishtp nvme_core ttm typec i2c_hid_acpi i2c_hid wmi pinctrl_tigerlake ip6_tables ip_tables i2c_dev fuse
[ 2038.884363] CPU: 6 PID: 5873 Comm: camerasrc0:src Tainted: G           O       6.2.0-rc1+ #26
[ 2038.884365] Hardware name: LENOVO 21CEZ9Q3US/21CEZ9Q3US, BIOS N3AET66W (1.31 ) 09/09/2022
[ 2038.884367] RIP: 0010:dma_buf_map_attachment+0x92/0x120
[ 2038.884369] Code: c7 c0 ea ff ff ff 48 83 c4 08 5b 5d c3 cc cc cc cc 48 8b b8 b0 00 00 00 be ff ff ff ff 48 83 c7 68 e8 22 52 53 00 85 c0 75 ab <0f> 0b 48 8b 43 20 48 85 c0 75 a9 48 8b 03 48 8b 40 20 48 8b 40 18
[ 2038.884370] RSP: 0018:ffffaf70c9fbbd48 EFLAGS: 00010246
[ 2038.884372] RAX: 0000000000000000 RBX: ffff8a6df34f9840 RCX: 0000000000000001
[ 2038.884373] RDX: 0000000000000000 RSI: ffffffffb195f239 RDI: ffffffffb1a00036
[ 2038.884374] RBP: 0000000000000000 R08: 0000000000000000 R09: 0000000000000001
[ 2038.884375] R10: 0000000000000000 R11: 0000000000012000 R12: ffff8a6df34f9840
[ 2038.884376] R13: ffff8a6dc1d08400 R14: ffff8a6e23fd8028 R15: ffff8a6dee040400
[ 2038.884377] FS:  00007f1d8dcfd6c0(0000) GS:ffff8a70fd580000(0000) knlGS:0000000000000000
[ 2038.884378] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 2038.884380] CR2: 00007f1d9017a210 CR3: 0000000145eb8004 CR4: 0000000000770ee0
[ 2038.884381] PKRU: 55555554
[ 2038.884382] Call Trace:
[ 2038.884383]  <TASK>
[ 2038.884385]  ipu_psys_mapbuf_locked+0x116/0x430 [intel_ipu6_psys]
[ 2038.884394]  ipu_psys_ioctl+0x1b1/0x4f0 [intel_ipu6_psys]
[ 2038.884398]  ? ioctl_has_perm.constprop.0.isra.0+0xaa/0xf0
[ 2038.884404]  ? lock_release+0x135/0x2d0
[ 2038.884411]  __x64_sys_ioctl+0x8d/0xd0
[ 2038.884415]  do_syscall_64+0x58/0x80
[ 2038.884418]  ? lockdep_hardirqs_on+0x7d/0x100
[ 2038.884421]  ? do_syscall_64+0x67/0x80
[ 2038.884423]  ? do_syscall_64+0x67/0x80
[ 2038.884425]  ? asm_exc_page_fault+0x22/0x30
[ 2038.884429]  ? lockdep_hardirqs_on+0x7d/0x100
[ 2038.884431]  entry_SYSCALL_64_after_hwframe+0x72/0xdc
[ 2038.884433] RIP: 0033:0x7f1d9e027baf
[ 2038.884434] Code: 00 48 89 44 24 18 31 c0 48 8d 44 24 60 c7 04 24 10 00 00 00 48 89 44 24 08 48 8d 44 24 20 48 89 44 24 10 b8 10 00 00 00 0f 05 <89> c2 3d 00 f0 ff ff 77 18 48 8b 44 24 18 64 48 2b 04 25 28 00 00
[ 2038.884436] RSP: 002b:00007f1d8dcfc220 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
[ 2038.884437] RAX: ffffffffffffffda RBX: 00007f1d803743c0 RCX: 00007f1d9e027baf
[ 2038.884438] RDX: 0000000000000013 RSI: 00000000c0044102 RDI: 0000000000000012
[ 2038.884439] RBP: 00007f1d80374330 R08: 00007f1d803743b0 R09: 00007f1d80000690
[ 2038.884440] R10: 0000000000000000 R11: 0000000000000246 R12: 00007f1d80374150
[ 2038.884441] R13: 0000000000000000 R14: 00007f1d80375000 R15: 00007f1d8dcfc34c
[ 2038.884448]  </TASK>
[ 2038.884449] irq event stamp: 115067
[ 2038.884450] hardirqs last  enabled at (115073): [<ffffffffb019fade>] __up_console_sem+0x5e/0x70
[ 2038.884453] hardirqs last disabled at (115078): [<ffffffffb019fac3>] __up_console_sem+0x43/0x70
[ 2038.884455] softirqs last  enabled at (113782): [<ffffffffb010bd3d>] __irq_exit_rcu+0xed/0x160
[ 2038.884458] softirqs last disabled at (113777): [<ffffffffb010bd3d>] __irq_exit_rcu+0xed/0x160
[ 2038.884460] ---[ end trace 0000000000000000 ]---
```

Note this backtrace repeats many times and the driver does not work without this fix.

Before merging this #67 and #68 really should be merged, these are necessary to get the driver to build / work with 6.1 and thus are also necessary for using the driver with 6.2.

Cc: @mrhpearson, @vicamo

@hao-yao it would be nice if we can get all these fixes pull-reqs which make the driver work with newer kernels merged!