### PR TITLE
Make IPU6 sensors code work with unpatched upstream kernels >= 6.1.7

### DIFF
--- a/drivers/media/i2c/hm11b1.c
+++ b/drivers/media/i2c/hm11b1.c
@@ -468,8 +468,13 @@ struct hm11b1 {
 	struct gpio_desc *reset_gpio;
 	/* GPIO for powerdown */
 	struct gpio_desc *powerdown_gpio;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	/* GPIO for clock enable */
 	struct gpio_desc *clken_gpio;
+#else
+	/* Clock provider */
+	struct clk *clk;
+#endif
 	/* GPIO for privacy LED */
 	struct gpio_desc *pled_gpio;
 #endif
@@ -508,7 +513,14 @@ static void hm11b1_set_power(struct hm11b1 *hm11b1, int on)
 		return;
 	gpiod_set_value_cansleep(hm11b1->reset_gpio, on);
 	gpiod_set_value_cansleep(hm11b1->powerdown_gpio, on);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	gpiod_set_value_cansleep(hm11b1->clken_gpio, on);
+#else
+	if (on)
+		clk_prepare_enable(hm11b1->clk);
+	else
+		clk_disable_unprepare(hm11b1->clk);
+#endif
 	gpiod_set_value_cansleep(hm11b1->pled_gpio, on);
 	msleep(20);
 #elif IS_ENABLED(CONFIG_POWER_CTRL_LOGIC)
@@ -1093,12 +1105,18 @@ static int hm11b1_parse_dt(struct hm11b1 *hm11b1)
 		return ret;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	hm11b1->clken_gpio = devm_gpiod_get(dev, "clken", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(hm11b1->clken_gpio);
 	if (ret < 0) {
 		dev_err(dev, "error while getting clken_gpio gpio: %d\n", ret);
 		return ret;
 	}
+#else
+	hm11b1->clk = devm_clk_get_optional(dev, "clk");
+	if (IS_ERR(hm11b1->clk))
+		return dev_err_probe(dev, PTR_ERR(hm11b1->clk), "getting clk\n");
+#endif
 
 	hm11b1->pled_gpio = devm_gpiod_get(dev, "pled", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(hm11b1->pled_gpio);

--- a/drivers/media/i2c/hm11b1.c
+++ b/drivers/media/i2c/hm11b1.c
@@ -511,8 +511,8 @@ static void hm11b1_set_power(struct hm11b1 *hm11b1, int on)
 #if IS_ENABLED(CONFIG_INTEL_SKL_INT3472)
 	if (!(hm11b1->reset_gpio && hm11b1->powerdown_gpio))
 		return;
-	gpiod_set_value_cansleep(hm11b1->reset_gpio, on);
-	gpiod_set_value_cansleep(hm11b1->powerdown_gpio, on);
+	gpiod_set_value_cansleep(hm11b1->reset_gpio, !on);
+	gpiod_set_value_cansleep(hm11b1->powerdown_gpio, !on);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	gpiod_set_value_cansleep(hm11b1->clken_gpio, on);
 #else

--- a/drivers/media/i2c/hm11b1.c
+++ b/drivers/media/i2c/hm11b1.c
@@ -1118,7 +1118,7 @@ static int hm11b1_parse_dt(struct hm11b1 *hm11b1)
 		return dev_err_probe(dev, PTR_ERR(hm11b1->clk), "getting clk\n");
 #endif
 
-	hm11b1->pled_gpio = devm_gpiod_get(dev, "pled", GPIOD_OUT_HIGH);
+	hm11b1->pled_gpio = devm_gpiod_get_optional(dev, "pled", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(hm11b1->pled_gpio);
 	if (ret < 0) {
 		dev_err(dev, "error while getting pled gpio: %d\n", ret);

--- a/drivers/media/i2c/ov01a1s.c
+++ b/drivers/media/i2c/ov01a1s.c
@@ -317,8 +317,13 @@ struct ov01a1s {
 	struct gpio_desc *reset_gpio;
 	/* GPIO for powerdown */
 	struct gpio_desc *powerdown_gpio;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	/* GPIO for clock enable */
 	struct gpio_desc *clken_gpio;
+#else
+	/* Clock provider */
+	struct clk *clk;
+#endif
 	/* GPIO for privacy LED */
 	struct gpio_desc *pled_gpio;
 #endif
@@ -339,7 +344,14 @@ static void ov01a1s_set_power(struct ov01a1s *ov01a1s, int on)
 		return;
 	gpiod_set_value_cansleep(ov01a1s->reset_gpio, on);
 	gpiod_set_value_cansleep(ov01a1s->powerdown_gpio, on);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	gpiod_set_value_cansleep(ov01a1s->clken_gpio, on);
+#else
+	if (on)
+		clk_prepare_enable(ov01a1s->clk);
+	else
+		clk_disable_unprepare(ov01a1s->clk);
+#endif
 	gpiod_set_value_cansleep(ov01a1s->pled_gpio, on);
 	msleep(20);
 #elif IS_ENABLED(CONFIG_POWER_CTRL_LOGIC)
@@ -945,12 +957,18 @@ static int ov01a1s_parse_dt(struct ov01a1s *ov01a1s)
 		return -EPROBE_DEFER;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	ov01a1s->clken_gpio = devm_gpiod_get(dev, "clken", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(ov01a1s->clken_gpio);
 	if (ret < 0) {
 		dev_err(dev, "error while getting clken_gpio gpio: %d\n", ret);
 		return -EPROBE_DEFER;
 	}
+#else
+	ov01a1s->clk = devm_clk_get_optional(dev, "clk");
+	if (IS_ERR(ov01a1s->clk))
+		return dev_err_probe(dev, PTR_ERR(ov01a1s->clk), "getting clk\n");
+#endif
 
 	ov01a1s->pled_gpio = devm_gpiod_get(dev, "pled", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(ov01a1s->pled_gpio);

--- a/drivers/media/i2c/ov01a1s.c
+++ b/drivers/media/i2c/ov01a1s.c
@@ -342,8 +342,8 @@ static void ov01a1s_set_power(struct ov01a1s *ov01a1s, int on)
 #if IS_ENABLED(CONFIG_INTEL_SKL_INT3472)
 	if (!(ov01a1s->reset_gpio && ov01a1s->powerdown_gpio))
 		return;
-	gpiod_set_value_cansleep(ov01a1s->reset_gpio, on);
-	gpiod_set_value_cansleep(ov01a1s->powerdown_gpio, on);
+	gpiod_set_value_cansleep(ov01a1s->reset_gpio, !on);
+	gpiod_set_value_cansleep(ov01a1s->powerdown_gpio, !on);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 7)
 	gpiod_set_value_cansleep(ov01a1s->clken_gpio, on);
 #else

--- a/drivers/media/i2c/ov01a1s.c
+++ b/drivers/media/i2c/ov01a1s.c
@@ -988,7 +988,6 @@ static int ov01a1s_probe(struct i2c_client *client)
 #if IS_ENABLED(CONFIG_INTEL_VSC)
 	struct vsc_mipi_config conf;
 	struct vsc_camera_status status;
-	s64 link_freq;
 #endif
 
 	ov01a1s = devm_kzalloc(&client->dev, sizeof(*ov01a1s), GFP_KERNEL);

--- a/drivers/media/i2c/ov01a1s.c
+++ b/drivers/media/i2c/ov01a1s.c
@@ -970,7 +970,7 @@ static int ov01a1s_parse_dt(struct ov01a1s *ov01a1s)
 		return dev_err_probe(dev, PTR_ERR(ov01a1s->clk), "getting clk\n");
 #endif
 
-	ov01a1s->pled_gpio = devm_gpiod_get(dev, "pled", GPIOD_OUT_HIGH);
+	ov01a1s->pled_gpio = devm_gpiod_get_optional(dev, "pled", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(ov01a1s->pled_gpio);
 	if (ret < 0) {
 		dev_err(dev, "error while getting pled gpio: %d\n", ret);

--- a/drivers/media/i2c/ov2740.c
+++ b/drivers/media/i2c/ov2740.c
@@ -594,8 +594,6 @@ static u64 to_pixels_per_line(u32 hts, u32 f_index)
 
 static void ov2740_set_power(struct ov2740 *ov2740, int on)
 {
-	if (!(ov2740->reset_gpio && ov2740->pled_gpio))
-		return;
 	gpiod_set_value_cansleep(ov2740->reset_gpio, !on);
 	gpiod_set_value_cansleep(ov2740->pled_gpio, on);
 	msleep(20);
@@ -633,7 +631,7 @@ static int ov2740_parse_dt(struct ov2740 *ov2740)
 		return ret;
 	}
 
-	ov2740->pled_gpio = devm_gpiod_get(dev, "pled", GPIOD_OUT_HIGH);
+	ov2740->pled_gpio = devm_gpiod_get_optional(dev, "pled", GPIOD_OUT_HIGH);
 	ret = PTR_ERR_OR_ZERO(ov2740->pled_gpio);
 	if (ret < 0) {
 		dev_err(dev, "error while getting pled gpio: %d\n", ret);

--- a/drivers/media/i2c/ov2740.c
+++ b/drivers/media/i2c/ov2740.c
@@ -596,7 +596,7 @@ static void ov2740_set_power(struct ov2740 *ov2740, int on)
 {
 	if (!(ov2740->reset_gpio && ov2740->pled_gpio))
 		return;
-	gpiod_set_value_cansleep(ov2740->reset_gpio, on);
+	gpiod_set_value_cansleep(ov2740->reset_gpio, !on);
 	gpiod_set_value_cansleep(ov2740->pled_gpio, on);
 	msleep(20);
 }

--- a/patch/int3472-support-independent-clock-and-LED-gpios-5.17+.patch
+++ b/patch/int3472-support-independent-clock-and-LED-gpios-5.17+.patch
@@ -65,7 +65,7 @@ index ed4c9d760757..f5857ec334fa 100644
  	case INT3472_GPIO_TYPE_RESET:
  		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, "reset",
 -						     GPIO_ACTIVE_LOW);
-+						     polarity);
++						     polarity ^ GPIO_ACTIVE_LOW);
  		if (ret)
  			err_msg = "Failed to map reset pin to sensor\n";
  
@@ -73,7 +73,7 @@ index ed4c9d760757..f5857ec334fa 100644
  	case INT3472_GPIO_TYPE_POWERDOWN:
  		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, "powerdown",
 -						     GPIO_ACTIVE_LOW);
-+						     polarity);
++						     polarity ^ GPIO_ACTIVE_LOW);
  		if (ret)
  			err_msg = "Failed to map powerdown pin to sensor\n";
  

--- a/patch/int3472-support-independent-clock-and-LED-gpios.patch
+++ b/patch/int3472-support-independent-clock-and-LED-gpios.patch
@@ -65,7 +65,7 @@ index e59d79c7e82f..5cf6dd63d43f 100644
  	case INT3472_GPIO_TYPE_RESET:
  		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, "reset",
 -						     GPIO_ACTIVE_LOW);
-+						     polarity);
++						     polarity ^ GPIO_ACTIVE_LOW);
  		if (ret)
  			err_msg = "Failed to map reset pin to sensor\n";
  
@@ -73,7 +73,7 @@ index e59d79c7e82f..5cf6dd63d43f 100644
  	case INT3472_GPIO_TYPE_POWERDOWN:
  		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, "powerdown",
 -						     GPIO_ACTIVE_LOW);
-+						     polarity);
++						     polarity ^ GPIO_ACTIVE_LOW);
  		if (ret)
  			err_msg = "Failed to map powerdown pin to sensor\n";
  


### PR DESCRIPTION
Starting with kernel 6.1.7 this commit is upstream:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cf5ac2d45f6e4d11ad78e7b10ae9a4121ba5e995

"platform/x86: int3472/discrete: Ensure the clk/power enable pins are in output mode"

This fixes a bug which was causing the INT3472 to not work correctly in some cases.

With this fixed it is possible to use the ipu6-drivers sensor drivers with an unmodified upstream kernel by switching to the clk-framework for clk-control as done by other upstream drivers in combination with fixing the polarity of the reset + powerdown signals and making the privacy-led GPIO optional.