### PR TITLE
Don't rename the already registered PCI-device

### DIFF
--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -299,7 +299,7 @@ static int ipu_init_debugfs(struct ipu_device *isp)
 	struct dentry *file;
 	struct dentry *dir;
 
-	dir = debugfs_create_dir(pci_name(isp->pdev), NULL);
+	dir = debugfs_create_dir(IPU_NAME, NULL);
 	if (!dir)
 		return -ENOMEM;
 
@@ -438,7 +438,6 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (!isp)
 		return -ENOMEM;
 
-	dev_set_name(&pdev->dev, "intel-ipu");
 	isp->pdev = pdev;
 	INIT_LIST_HEAD(&isp->devices);
 


### PR DESCRIPTION
Devices must not be renamed after they have already been added to the device hierarchy.

dev_set_name() MUST only be called before dev_add() and the pci_dev passed to ipu_pci_probe() has been added long before ipu_pci_probe() runs, so it must not rename it.

Renaming it is confusing udevd which now all of a sudden sees a device it already knows about change name.

This is causing udev rules to not work properly with the ipu6-driver. Drop the clearly wrong dev_set_name() call.