### PR TITLE
ipu6-isys-subdev: add Y8 to mbus code conversion functions.

### DIFF
--- a/drivers/media/pci/intel/ipu-isys-subdev.c
+++ b/drivers/media/pci/intel/ipu-isys-subdev.c
@@ -34,6 +34,7 @@ unsigned int ipu_isys_mbus_code_to_bpp(u32 code)
 	case MEDIA_BUS_FMT_SGRBG10_1X10:
 	case MEDIA_BUS_FMT_SRGGB10_1X10:
 		return 10;
+	case MEDIA_BUS_FMT_Y8_1X8:
 	case MEDIA_BUS_FMT_SBGGR8_1X8:
 	case MEDIA_BUS_FMT_SGBRG8_1X8:
 	case MEDIA_BUS_FMT_SGRBG8_1X8:
@@ -72,6 +73,7 @@ unsigned int ipu_isys_mbus_code_to_mipi(u32 code)
 	case MEDIA_BUS_FMT_SGRBG10_1X10:
 	case MEDIA_BUS_FMT_SRGGB10_1X10:
 		return IPU_ISYS_MIPI_CSI2_TYPE_RAW10;
+	case MEDIA_BUS_FMT_Y8_1X8:
 	case MEDIA_BUS_FMT_SBGGR8_1X8:
 	case MEDIA_BUS_FMT_SGBRG8_1X8:
 	case MEDIA_BUS_FMT_SGRBG8_1X8:


### PR DESCRIPTION
Following support for MEDIA_BUS_FMT_Y8_1X8:
ipu_isys_mbus_code_to_bpp
ipu_isys_mbus_code_to_mipi

Link validation fix.