### PR TITLE
iotg mtl alpha release v1.0.1 - media/ipu6: disable the ATS for IPU6 on MTL ES2

### DIFF
--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -9,6 +9,7 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/pci.h>
+#include <linux/pci-ats.h>
 #include <linux/pm_qos.h>
 #include <linux/pm_runtime.h>
 #include <linux/timer.h>
@@ -355,6 +356,11 @@ static int ipu_pci_config_setup(struct pci_dev *dev)
 	pci_read_config_word(dev, PCI_COMMAND, &pci_command);
 	pci_command |= PCI_COMMAND_MEMORY | PCI_COMMAND_MASTER;
 	pci_write_config_word(dev, PCI_COMMAND, pci_command);
+
+	/* disable IPU6 PCI ATS on mtl ES2 */
+	if (ipu_ver == IPU_VER_6EP_MTL && boot_cpu_data.x86_stepping == 0x2 &&
+	    pci_ats_supported(dev))
+		pci_disable_ats(dev);
 
 	/* no msi pci capability for IPU6EP */
 	if (ipu_ver == IPU_VER_6EP || ipu_ver == IPU_VER_6EP_MTL) {


### PR DESCRIPTION
For MTL ES2, something is wrong with the devTLB invalidation for IPU, it will cause the transaction between IPU and IOMMU failure. Once vt-d enabled in the system, it will cause system hang. Solution is to disable the PCI ATS for IPU which was enabled by default.

Test Platform:
mtlrvp
rex-ES2