### PR TITLE
intel_ipu6_isys: Add video_nr module parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,9 +112,9 @@ jobs:
                                   add-apt-repository ppa:canonical-kernel-team/unstable
                                   apt-get update --quiet;
                                   # latest and wip generic kernel headers
-                                  apt-get install --yes linux-headers-generic
+                                  apt-get install --yes linux-headers-generic linux-headers-generic-wip
                                   # latest oem kernel
-                                  apt-get install --yes linux-headers-oem-22.04 linux-headers-oem-22.04a
+                                  apt-get install --yes linux-headers-oem-20.04
 
                         - name: Register with dkms
                           shell: bash


### PR DESCRIPTION
Add a video_nr module parameter so that the isys /dev/video# node can be assigned a fixed number instead of taking the first available free number.

Both Ubuntu and Fedora by default use the IPU6 camera stack together with v4l2loopback for compat with apps which expect a regular video4linux2 device.

Most apps open /dev/video0 by default so we want that to be the v4l2loopback device. But currently if the ipu6-drivers load first they become /dev/video0.

This new video_nr module parameter allows distros to specify a different fixed number for intel_ipu6_isys so that v4l2loopback becomes /dev/video0 independent of the probe ordering.