### PR TITLE
mfd: lpss: Fix enumerate i2c device issue with kernels < 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,7 @@ Three ways are available:
 	sudo dkms add .
 	sudo dkms autoinstall ipu6-drivers/0.0.0
 	```
+
+### Note
+If your kernel version is below v5.19, you will need to apply this patch.
+On the intel platform, The i2c port 6 and 7 might not have been registered in the PCIe bus.

--- a/patch/0001-mfd-lpss-Fix-enumerate-i2c-device-issue.patch
+++ b/patch/0001-mfd-lpss-Fix-enumerate-i2c-device-issue.patch
@@ -1,0 +1,29 @@
+From 7d333ca1a7e9ada6e8513fc90c067616c0172036 Mon Sep 17 00:00:00 2001
+From: "jason.z.chen" <jason.z.chen@intel.com>
+Date: Thu, 2 Feb 2023 16:28:17 +0800
+Subject: [PATCH] mfd: lpss: Fix enumerate i2c device issue
+
+Add the device id of pci for i2c controller which can be
+recognized by lpss driver
+
+Signed-off-by: jason.z.chen <jason.z.chen@intel.com>
+---
+ drivers/mfd/intel-lpss-pci.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/mfd/intel-lpss-pci.c b/drivers/mfd/intel-lpss-pci.c
+index c54d19fb184c..2d7e73477714 100644
+--- a/drivers/mfd/intel-lpss-pci.c
++++ b/drivers/mfd/intel-lpss-pci.c
+@@ -305,6 +305,8 @@ static const struct pci_device_id intel_lpss_pci_ids[] = {
+ 	{ PCI_VDEVICE(INTEL, 0x51c5), (kernel_ulong_t)&bxt_i2c_info },
+ 	{ PCI_VDEVICE(INTEL, 0x51c6), (kernel_ulong_t)&bxt_i2c_info },
+ 	{ PCI_VDEVICE(INTEL, 0x51c7), (kernel_ulong_t)&bxt_uart_info },
++	{ PCI_VDEVICE(INTEL, 0x51d8), (kernel_ulong_t)&bxt_i2c_info },
++	{ PCI_VDEVICE(INTEL, 0x51d9), (kernel_ulong_t)&bxt_i2c_info },
+ 	{ PCI_VDEVICE(INTEL, 0x51e8), (kernel_ulong_t)&bxt_i2c_info },
+ 	{ PCI_VDEVICE(INTEL, 0x51e9), (kernel_ulong_t)&bxt_i2c_info },
+ 	{ PCI_VDEVICE(INTEL, 0x51ea), (kernel_ulong_t)&bxt_i2c_info },
+-- 
+2.34.1
+


### PR DESCRIPTION
Add the device id of pci for i2c controller which can be recognized by lpss driver