### PR TITLE
ipu6: Fix ipu_buttress_exit() not being called on fw load failure

### DIFF
--- a/drivers/media/pci/intel/ipu.c
+++ b/drivers/media/pci/intel/ipu.c
@@ -550,7 +550,7 @@ static int ipu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	rval = request_cpd_fw(&isp->cpd_fw, isp->cpd_fw_name, &pdev->dev);
 	if (rval) {
 		dev_err(&isp->pdev->dev, "Requesting signed firmware failed\n");
-		return rval;
+		goto buttress_exit;
 	}
 
 	rval = ipu_cpd_validate_cpd_file(isp, isp->cpd_fw->data,
@@ -688,8 +688,9 @@ out_ipu_bus_del_devices:
 	if (!IS_ERR_OR_NULL(isp->psys))
 		pm_runtime_put(&isp->psys->dev);
 	ipu_bus_del_devices(pdev);
-	ipu_buttress_exit(isp);
 	release_firmware(isp->cpd_fw);
+buttress_exit:
+	ipu_buttress_exit(isp);
 
 	return rval;
 }


### PR DESCRIPTION
ipu_pci_probe() did not call ipu_buttress_exit() on fw load errors, causing the following oops when trying to load the module a second time (rmmod + modprobe) after installing the firmware:

```
[  717.471913] sysfs: cannot create duplicate filename '/devices/pci0000:00/0000:00:05.0/psys_fused_min_freq'
[  717.471917] CPU: 3 PID: 2535 Comm: modprobe Tainted: G           OE      6.4.0-rc6+ #11
[  717.471920] Hardware name: Default string Default string/Default string, BIOS JP2V1.09 07/29/2022
[  717.471923] Call Trace:
[  717.471928]  <TASK>
[  717.471932]  dump_stack_lvl+0x71/0x90
[  717.471941]  sysfs_warn_dup+0x56/0x70
[  717.471948]  sysfs_add_file_mode_ns+0x12d/0x140
[  717.471953]  sysfs_create_file_ns+0x4f/0x70
[  717.471958]  ipu_buttress_init+0x326/0x490 [intel_ipu6]
[  717.471975]  ipu_pci_probe+0x322/0xc60 [intel_ipu6]
...
```

Properly call ipu_buttress_exit() to fix this.