### PR TITLE
ipu6: Fix compilation with kernels >= 6.6.0

### DIFF
--- a/drivers/media/i2c/gc5035.c
+++ b/drivers/media/i2c/gc5035.c
@@ -2187,7 +2187,11 @@ static struct i2c_driver gc5035_i2c_driver = {
 		.acpi_match_table = ACPI_PTR(gc5035_acpi_ids),
 		.of_match_table = gc5035_of_match,
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new	= gc5035_probe,
+#else
+	.probe		= gc5035_probe,
+#endif
 	.remove		= gc5035_remove,
 };
 module_i2c_driver(gc5035_i2c_driver);

--- a/drivers/media/i2c/hi556.c
+++ b/drivers/media/i2c/hi556.c
@@ -1452,7 +1452,11 @@ static struct i2c_driver hi556_i2c_driver = {
 		.pm = &hi556_pm_ops,
 		.acpi_match_table = ACPI_PTR(hi556_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = hi556_probe,
+#else
+	.probe = hi556_probe,
+#endif
 	.remove = hi556_remove,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
 	.flags = I2C_DRV_ACPI_WAIVE_D0_PROBE,

--- a/drivers/media/i2c/hm11b1.c
+++ b/drivers/media/i2c/hm11b1.c
@@ -1229,7 +1229,11 @@ static struct i2c_driver hm11b1_i2c_driver = {
 		.pm = &hm11b1_pm_ops,
 		.acpi_match_table = ACPI_PTR(hm11b1_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = hm11b1_probe,
+#else
+	.probe = hm11b1_probe,
+#endif
 	.remove = hm11b1_remove,
 };
 

--- a/drivers/media/i2c/hm2170.c
+++ b/drivers/media/i2c/hm2170.c
@@ -1324,7 +1324,11 @@ static struct i2c_driver hm2170_i2c_driver = {
 		.pm = &hm2170_pm_ops,
 		.acpi_match_table = hm2170_acpi_ids,
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = hm2170_probe,
+#else
+	.probe = hm2170_probe,
+#endif
 	.remove = hm2170_remove,
 };
 

--- a/drivers/media/i2c/hm2172.c
+++ b/drivers/media/i2c/hm2172.c
@@ -1628,7 +1628,11 @@ static struct i2c_driver hm2172_i2c_driver = {
 		.pm = &hm2172_pm_ops,
 		.acpi_match_table = hm2172_acpi_ids,
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = hm2172_probe,
+#else
+	.probe = hm2172_probe,
+#endif
 	.remove = hm2172_remove,
 };
 

--- a/drivers/media/i2c/ov01a10.c
+++ b/drivers/media/i2c/ov01a10.c
@@ -1025,7 +1025,11 @@ static struct i2c_driver ov01a10_i2c_driver = {
 		.pm = &ov01a10_pm_ops,
 		.acpi_match_table = ACPI_PTR(ov01a10_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov01a10_probe,
+#else
+	.probe = ov01a10_probe,
+#endif
 	.remove = ov01a10_remove,
 };
 

--- a/drivers/media/i2c/ov01a1s.c
+++ b/drivers/media/i2c/ov01a1s.c
@@ -1172,7 +1172,11 @@ static struct i2c_driver ov01a1s_i2c_driver = {
 		.pm = &ov01a1s_pm_ops,
 		.acpi_match_table = ACPI_PTR(ov01a1s_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov01a1s_probe,
+#else
+	.probe = ov01a1s_probe,
+#endif
 	.remove = ov01a1s_remove,
 };
 

--- a/drivers/media/i2c/ov02c10.c
+++ b/drivers/media/i2c/ov02c10.c
@@ -1525,7 +1525,11 @@ static struct i2c_driver ov02c10_i2c_driver = {
 		.pm = &ov02c10_pm_ops,
 		.acpi_match_table = ACPI_PTR(ov02c10_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov02c10_probe,
+#else
+	.probe = ov02c10_probe,
+#endif
 	.remove = ov02c10_remove,
 };
 

--- a/drivers/media/i2c/ov02e10.c
+++ b/drivers/media/i2c/ov02e10.c
@@ -1025,7 +1025,11 @@ static struct i2c_driver ov02e10_i2c_driver = {
 		   .pm = &ov02e10_pm_ops,
 		   .acpi_match_table = ov02e10_acpi_ids,
 		    },
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov02e10_probe,
+#else
+	.probe = ov02e10_probe,
+#endif
 	.remove = ov02e10_remove,
 };
 

--- a/drivers/media/i2c/ov08a10.c
+++ b/drivers/media/i2c/ov08a10.c
@@ -1131,7 +1131,11 @@ static struct i2c_driver ov08a10_i2c_driver = {
 		.pm = &ov08a10_pm_ops,
 		.acpi_match_table = ov08a10_acpi_ids,
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov08a10_probe,
+#else
+	.probe = ov08a10_probe,
+#endif
 	.remove = ov08a10_remove,
 };
 

--- a/drivers/media/i2c/ov2740.c
+++ b/drivers/media/i2c/ov2740.c
@@ -1611,7 +1611,11 @@ static struct i2c_driver ov2740_i2c_driver = {
 		.pm = &ov2740_pm_ops,
 		.acpi_match_table = ov2740_acpi_ids,
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov2740_probe,
+#else
+	.probe = ov2740_probe,
+#endif
 	.remove = ov2740_remove,
 };
 

--- a/drivers/media/i2c/ov8856.c
+++ b/drivers/media/i2c/ov8856.c
@@ -1308,7 +1308,11 @@ static struct i2c_driver ov8856_i2c_driver = {
 		.pm = &ov8856_pm_ops,
 		.acpi_match_table = ACPI_PTR(ov8856_acpi_ids),
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	.probe_new = ov8856_probe,
+#else
+	.probe = ov8856_probe,
+#endif
 	.remove = ov8856_remove,
 	.id_table = ov8856_id_table,
 };

--- a/drivers/media/pci/intel/ipu-isys.c
+++ b/drivers/media/pci/intel/ipu-isys.c
@@ -723,6 +723,7 @@ static int isys_iwake_watermark_cleanup(struct ipu_isys *isys)
 }
 
 /* The .bound() notifier callback when a match is found */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 static int isys_notifier_bound(struct v4l2_async_notifier *notifier,
 			       struct v4l2_subdev *sd,
 			       struct v4l2_async_subdev *asd)
@@ -748,6 +749,33 @@ static void isys_notifier_unbind(struct v4l2_async_notifier *notifier,
 
 	dev_info(&isys->adev->dev, "unbind %s\n", sd->name);
 }
+#else
+static int isys_notifier_bound(struct v4l2_async_notifier *notifier,
+			       struct v4l2_subdev *sd,
+			       struct v4l2_async_connection *asc)
+{
+	struct ipu_isys *isys = container_of(notifier,
+					struct ipu_isys, notifier);
+	struct sensor_async_sd *s_asd = container_of(asc,
+					struct sensor_async_sd, asc);
+
+	dev_info(&isys->adev->dev, "bind %s nlanes is %d port is %d\n",
+		 sd->name, s_asd->csi2.nlanes, s_asd->csi2.port);
+	isys_complete_ext_device_registration(isys, sd, &s_asd->csi2);
+
+	return v4l2_device_register_subdev_nodes(&isys->v4l2_dev);
+}
+
+static void isys_notifier_unbind(struct v4l2_async_notifier *notifier,
+				 struct v4l2_subdev *sd,
+				 struct v4l2_async_connection *asc)
+{
+	struct ipu_isys *isys = container_of(notifier,
+					struct ipu_isys, notifier);
+
+	dev_info(&isys->adev->dev, "unbind %s\n", sd->name);
+}
+#endif
 
 static int isys_notifier_complete(struct v4l2_async_notifier *notifier)
 {
@@ -765,6 +793,7 @@ static const struct v4l2_async_notifier_operations isys_async_ops = {
 	.complete = isys_notifier_complete,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 static int isys_fwnode_parse(struct device *dev,
 			     struct v4l2_fwnode_endpoint *vep,
 			     struct v4l2_async_subdev *asd)
@@ -777,6 +806,7 @@ static int isys_fwnode_parse(struct device *dev,
 
 	return 0;
 }
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0) && LINUX_VERSION_CODE != KERNEL_VERSION(5, 15, 71)
 static int isys_notifier_init(struct ipu_isys *isys)
@@ -813,13 +843,7 @@ static int isys_notifier_init(struct ipu_isys *isys)
 
 	return ret;
 }
-
-static void isys_notifier_cleanup(struct ipu_isys *isys)
-{
-	v4l2_async_notifier_unregister(&isys->notifier);
-	v4l2_async_notifier_cleanup(&isys->notifier);
-}
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 static int isys_notifier_init(struct ipu_isys *isys)
 {
 	struct ipu_device *isp = isys->adev->isp;
@@ -852,7 +876,79 @@ static int isys_notifier_init(struct ipu_isys *isys)
 
 	return ret;
 }
+#else
+static int isys_notifier_init(struct ipu_isys *isys)
+{
+	const struct ipu_isys_internal_csi2_pdata *csi2 =
+	    &isys->pdata->ipdata->csi2;
+	struct ipu_device *isp = isys->adev->isp;
+	struct device *dev = &isp->pdev->dev;
+	unsigned int i;
+	int ret;
 
+	v4l2_async_nf_init(&isys->notifier, &isys->v4l2_dev);
+
+	for (i = 0; i < csi2->nports; i++) {
+		struct v4l2_fwnode_endpoint vep = {
+			.bus_type = V4L2_MBUS_CSI2_DPHY
+		};
+		struct sensor_async_sd *s_asd;
+		struct fwnode_handle *ep;
+
+		ep = fwnode_graph_get_endpoint_by_id(dev_fwnode(dev), i, 0,
+						FWNODE_GRAPH_ENDPOINT_NEXT);
+		if (!ep)
+			continue;
+
+		ret = v4l2_fwnode_endpoint_parse(ep, &vep);
+		if (ret)
+			goto err_parse;
+
+		s_asd = v4l2_async_nf_add_fwnode_remote(&isys->notifier, ep,
+							struct
+							sensor_async_sd);
+		if (IS_ERR(s_asd)) {
+			ret = PTR_ERR(s_asd);
+			goto err_parse;
+		}
+
+		s_asd->csi2.port = vep.base.port;
+		s_asd->csi2.nlanes = vep.bus.mipi_csi2.num_data_lanes;
+
+		fwnode_handle_put(ep);
+
+		continue;
+
+err_parse:
+		fwnode_handle_put(ep);
+		return ret;
+	}
+
+	if (list_empty(&isys->notifier.waiting_list)) {
+		/* isys probe could continue with async subdevs missing */
+		dev_warn(&isys->adev->dev, "no subdev found in graph\n");
+		return 0;
+	}
+
+	isys->notifier.ops = &isys_async_ops;
+	ret = v4l2_async_nf_register(&isys->notifier);
+	if (ret) {
+		dev_err(&isys->adev->dev,
+			"failed to register async notifier : %d\n", ret);
+		v4l2_async_nf_cleanup(&isys->notifier);
+	}
+
+	return ret;
+}
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0) && LINUX_VERSION_CODE != KERNEL_VERSION(5, 15, 71)
+static void isys_notifier_cleanup(struct ipu_isys *isys)
+{
+	v4l2_async_notifier_unregister(&isys->notifier);
+	v4l2_async_notifier_cleanup(&isys->notifier);
+}
+#else
 static void isys_notifier_cleanup(struct ipu_isys *isys)
 {
 	v4l2_async_nf_unregister(&isys->notifier);

--- a/drivers/media/pci/intel/ipu6/ipu6-isys-phy.c
+++ b/drivers/media/pci/intel/ipu6/ipu6-isys-phy.c
@@ -504,12 +504,21 @@ int ipu6_isys_phy_common_init(struct ipu_isys *isys)
 	struct ipu_bus_device *adev = to_ipu_bus_device(&isys->adev->dev);
 	struct ipu_device *isp = adev->isp;
 	void __iomem *isp_base = isp->base;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	struct v4l2_async_subdev *asd;
 	struct sensor_async_subdev *s_asd;
 	unsigned int i;
 
 	list_for_each_entry(asd, &isys->notifier.asd_list, asd_list) {
 		s_asd = container_of(asd, struct sensor_async_subdev, asd);
+#else
+	struct v4l2_async_connection *asc;
+	struct sensor_async_sd *s_asd;
+	unsigned int i;
+
+	list_for_each_entry(asc, &isys->notifier.done_list, asc_entry) {
+		s_asd = container_of(asc, struct sensor_async_sd, asc);
+#endif
 		phy_id = s_asd->csi2.port / 4;
 		phy_base = isp_base + IPU6_ISYS_PHY_BASE(phy_id);
 
@@ -562,6 +571,7 @@ int ipu6_isys_phy_config(struct ipu_isys *isys)
 	struct ipu_device *isp = adev->isp;
 	void __iomem *isp_base = isp->base;
 	const struct phy_reg **phy_config_regs;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	struct v4l2_async_subdev *asd;
 	struct sensor_async_subdev *s_asd;
 	struct ipu_isys_csi2_config cfg;
@@ -569,6 +579,15 @@ int ipu6_isys_phy_config(struct ipu_isys *isys)
 
 	list_for_each_entry(asd, &isys->notifier.asd_list, asd_list) {
 		s_asd = container_of(asd, struct sensor_async_subdev, asd);
+#else
+	struct v4l2_async_connection *asc;
+	struct sensor_async_sd *s_asd;
+	struct ipu_isys_csi2_config cfg;
+	int i;
+
+	list_for_each_entry(asc, &isys->notifier.done_list, asc_entry) {
+		s_asd = container_of(asc, struct sensor_async_sd, asc);
+#endif
 		cfg.port = s_asd->csi2.port;
 		cfg.nlanes = s_asd->csi2.nlanes;
 		phy_port = ipu6_isys_driver_port_to_phy_port(&cfg);

--- a/include/media/ipu-isys.h
+++ b/include/media/ipu-isys.h
@@ -6,6 +6,7 @@
 
 #include <linux/i2c.h>
 #include <linux/clkdev.h>
+#include <linux/version.h>
 #include <media/v4l2-async.h>
 
 #define IPU_ISYS_MAX_CSI2_LANES		4
@@ -36,9 +37,16 @@ struct ipu_isys_subdev_pdata {
 	struct ipu_isys_clk_mapping *clk_map;
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 struct sensor_async_subdev {
 	struct v4l2_async_subdev asd;
 	struct ipu_isys_csi2_config csi2;
 };
 
+#else
+struct sensor_async_sd {
+	struct v4l2_async_connection asc;
+	struct ipu_isys_csi2_config csi2;
+};
+#endif
 #endif /* MEDIA_IPU_H */


### PR DESCRIPTION
Kernel 6.6 has made some significant changes to how v4l2-async (sub)dev registration works. Adjust the code accordingly.

Note this is based on building against a recent verison of the media_staging/master git tree. Since 6.6 has not been released yet there is a small chance that there might be some more work needed, but this should at least make things work with 6.6-rc1 once released.