### PR TITLE
media: ov2740: Fix "clk already disabled" / "already unprepared" oops / backtraces

### DIFF
--- a/drivers/media/i2c/ov2740.c
+++ b/drivers/media/i2c/ov2740.c
@@ -1529,8 +1529,10 @@ static int ov2740_probe(struct i2c_client *client)
 	ret = ov2740_parse_power(ov2740);
 	if (ret)
 		return ret;
-	gpiod_set_value_cansleep(ov2740->reset_gpio, 0);
-	msleep(20);
+
+	ret = ov2740_power_on(&client->dev);
+	if (ret)
+		return ret;
 #endif
 
 	ret = ov2740_identify_module(ov2740);


### PR DESCRIPTION
On probe() the ov2740 code was manually setting the reset GPIO instead of using the power_on() helper function.

This path however left out enabling the clk, which power_on() does do, so when power_off() runs after the probe() is done (on runtime suspend) then there are 2 ugly backtraces triggered by WARN()s in the clk-core. One for "clk already disabled" followed by one for "clk already unprepared".

Fix this by using the power_on() helper in probe().