### PR TITLE
media: i2c: Extends the delay to 25 ms

### DIFF
--- a/drivers/media/i2c/hi556.c
+++ b/drivers/media/i2c/hi556.c
@@ -989,8 +989,11 @@ static int hi556_power_on(struct device *dev)
 	}
 	gpiod_set_value_cansleep(hi556->handshake, 1);
 	gpiod_set_value_cansleep(hi556->reset, 0);
-	/* TODO: Test delay 2400 * MCLK */
-	usleep_range(5000, 5500);
+
+	/* Lattice MIPI aggregator with some version FW needs longer delay
+	   after handshake triggered. We set 25ms as a safe value and wait
+	   for a stable version FW. */
+	msleep_interruptible(25);
 
 	return ret;
 }

--- a/drivers/media/i2c/hm2172.c
+++ b/drivers/media/i2c/hm2172.c
@@ -1290,8 +1290,11 @@ static int hm2172_power_on(struct device *dev)
 
 	gpiod_set_value_cansleep(hm2172->handshake, 1);
 	gpiod_set_value_cansleep(hm2172->reset, 0);
-	/* 5ms to wait ready after XSHUTDN assert */
-	usleep_range(5000, 5500);
+
+	/* Lattice MIPI aggregator with some version FW needs longer delay
+	   after handshake triggered. We set 25ms as a safe value and wait
+	   for a stable version FW. */
+	msleep_interruptible(25);
 
 	return ret;
 }

--- a/drivers/media/i2c/ov02e10.c
+++ b/drivers/media/i2c/ov02e10.c
@@ -714,8 +714,11 @@ static int ov02e10_power_on(struct device *dev)
 	}
 	gpiod_set_value_cansleep(ov02e10->handshake, 1);
 	gpiod_set_value_cansleep(ov02e10->reset, 0);
-	/* 5ms to wait ready after XSHUTDN assert */
-	usleep_range(5000, 5500);
+
+	/* Lattice MIPI aggregator with some version FW needs longer delay
+	   after handshake triggered. We set 25ms as a safe value and wait
+	   for a stable version FW. */
+	msleep_interruptible(25);
 
 	return ret;
 }


### PR DESCRIPTION
Lattice MIPI aggregator with some version FW needs longer delay after handshake triggered. We set 25ms as a safe value and wait for a stable version FW.