### PR TITLE
Ipu6 kernel 6.7 and 6.8 fixes

### DIFF
--- a/drivers/media/pci/intel/cio2-bridge.c
+++ b/drivers/media/pci/intel/cio2-bridge.c
@@ -247,15 +247,13 @@ static void cio2_bridge_create_connection_swnodes(struct cio2_bridge *bridge,
 						  struct cio2_sensor *sensor)
 {
 	struct software_node *nodes = sensor->swnodes;
-	char sensor_node_name[ACPI_ID_LEN + 2];
-	char vcm_node_name[ACPI_ID_LEN + 2];
 
 	cio2_bridge_init_swnode_names(sensor);
 
-	snprintf(sensor_node_name, sizeof(sensor_node_name),
+	snprintf(sensor->node_names.sensor_name, sizeof(sensor->node_names.sensor_name),
 		 "%s-%u", sensor->name, sensor->ssdb.link);
 
-	nodes[SWNODE_SENSOR_HID] = NODE_SENSOR(sensor_node_name,
+	nodes[SWNODE_SENSOR_HID] = NODE_SENSOR(sensor->node_names.sensor_name,
 					       sensor->dev_properties);
 	nodes[SWNODE_SENSOR_PORT] = NODE_PORT(sensor->node_names.port,
 					      &nodes[SWNODE_SENSOR_HID]);
@@ -271,10 +269,10 @@ static void cio2_bridge_create_connection_swnodes(struct cio2_bridge *bridge,
 			      sensor->cio2_properties);
 	if (sensor->ssdb.vcmtype &&
 	    sensor->ssdb.vcmtype <= ARRAY_SIZE(cio2_vcm_types)) {
-		snprintf(vcm_node_name, sizeof(vcm_node_name),
+		snprintf(sensor->node_names.vcm_name, sizeof(sensor->node_names.vcm_name),
 			 "%s-%u", cio2_vcm_types[sensor->ssdb.vcmtype - 1],
 			 sensor->ssdb.link);
-		nodes[SWNODE_VCM] = NODE_VCM(vcm_node_name);
+		nodes[SWNODE_VCM] = NODE_VCM(sensor->node_names.vcm_name);
 	}
 
 	cio2_bridge_init_swnode_group(sensor);

--- a/drivers/media/pci/intel/cio2-bridge.h
+++ b/drivers/media/pci/intel/cio2-bridge.h
@@ -4,6 +4,7 @@
 #ifndef __CIO2_BRIDGE_H
 #define __CIO2_BRIDGE_H
 
+#include <linux/mod_devicetable.h>
 #include <linux/property.h>
 #include <linux/types.h>
 
@@ -106,6 +107,8 @@ struct cio2_node_names {
 	char port[7];
 	char endpoint[11];
 	char remote_port[7];
+	char sensor_name[ACPI_ID_LEN + 2];
+	char vcm_name[ACPI_ID_LEN + 2];
 };
 
 struct cio2_sensor_config {


### PR DESCRIPTION
Here is a set of 3 fixes to make ipu6-drivers work with the 6.7 and 6.8 kernels

1. The first commit fixes the ipu6-isys driver crashing (due to a bug in a cleanup on error paths) after a failure in isys_probe() (this fixes #205)
2. The second commit fixes the drivers not compiling against kernel 6.8
3. The third commit fixes the kernel crashing with kernel 6.8 due to the cio2-bridge code making the .name attribute of 2 long-lived software_nodes point to on stack memory

Cc: @vicamo @smallorange