### PR TITLE
media/pci: Add sensor OV08X40 information for IPU6

### DIFF
--- a/drivers/media/pci/intel/cio2-bridge.c
+++ b/drivers/media/pci/intel/cio2-bridge.c
@@ -55,6 +55,8 @@ static const struct cio2_sensor_config cio2_supported_sensors[] = {
 	CIO2_SENSOR_CONFIG("OVTI13B1", 1, 560000000),
 	/* Omnivision ov08a10 */
 	CIO2_SENSOR_CONFIG("OVTI08A1", 0, 0),
+	/* Omnivision ov08x40 */
+	CIO2_SENSOR_CONFIG("OVTI08F4", 1, 400000000),
 };
 
 static const struct cio2_property_names prop_names = {


### PR DESCRIPTION
CIO2 driver doesn't add new sensor OV08X40's information, so need to bind the camera sensor to IPU6 as a subdevice