### PR TITLE
gc5035: Fix compilation with kernels >= 6.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ export CONFIG_VIDEO_OV02E10 = m
 export CONFIG_VIDEO_HM2170 = m
 export CONFIG_VIDEO_HM2172 = m
 export CONFIG_VIDEO_HI556 = m
+export CONFIG_VIDEO_GC5035 = m
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
 export CONFIG_VIDEO_OV2740 = m
-export CONFIG_VIDEO_GC5035 = m
 endif
 obj-y += drivers/media/i2c/
 

--- a/drivers/media/i2c/gc5035.c
+++ b/drivers/media/i2c/gc5035.c
@@ -1497,7 +1497,11 @@ static int gc5035_set_fmt(struct v4l2_subdev *sd,
 
 	mutex_lock(&gc5035->mutex);
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 		*v4l2_subdev_get_try_format(sd, sd_state, fmt->pad) = fmt->format;
+#else
+		*v4l2_subdev_state_get_format(sd_state, fmt->pad) = fmt->format;
+#endif
 	} else {
 		gc5035->cur_mode = mode;
 		h_blank = mode->hts_def - mode->width;
@@ -1522,7 +1526,11 @@ static int gc5035_get_fmt(struct v4l2_subdev *sd,
 
 	mutex_lock(&gc5035->mutex);
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 		fmt->format = *v4l2_subdev_get_try_format(sd, sd_state, fmt->pad);
+#else
+		fmt->format = *v4l2_subdev_state_get_format(sd_state, fmt->pad);
+#endif
 	} else {
 		fmt->format.width = mode->width;
 		fmt->format.height = mode->height;
@@ -1714,7 +1722,9 @@ static const struct v4l2_subdev_video_ops gc5035_video_ops = {
 };
 
 static const struct v4l2_subdev_pad_ops gc5035_pad_ops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 	.init_cfg = gc5035_entity_init_cfg,
+#endif
 	.enum_mbus_code = gc5035_enum_mbus_code,
 	.enum_frame_size = gc5035_enum_frame_sizes,
 	.get_fmt = gc5035_get_fmt,
@@ -1729,6 +1739,12 @@ static const struct v4l2_subdev_ops gc5035_subdev_ops = {
 static const struct media_entity_operations gc5035_subdev_entity_ops = {
 	.link_validate = v4l2_subdev_link_validate,
 };
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+static const struct v4l2_subdev_internal_ops gc5035_internal_ops = {
+	.init_state = gc5035_entity_init_cfg,
+};
+#endif
 
 static int gc5035_set_exposure(struct gc5035 *gc5035, u32 val)
 {
@@ -2091,6 +2107,9 @@ static int gc5035_probe(struct i2c_client *client)
 	mutex_init(&gc5035->mutex);
 	sd = &gc5035->subdev;
 	v4l2_i2c_subdev_init(sd, client, &gc5035_subdev_ops);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+	sd->internal_ops = &gc5035_internal_ops;
+#endif
 	ret = gc5035_initialize_controls(gc5035);
 	if (ret) {
 		dev_err_probe(dev, ret, "Failed to initialize controls\n");


### PR DESCRIPTION
For some reason the gc5035 driver has been disabled for kernels >= 6.8, but it is not upstream yet.

Fix compilation with kernel >= 6.8 and re-enable the driver.