### PR TITLE
media: i2c: ov02c10: Probe defer while chip id is zero

### DIFF
--- a/drivers/media/i2c/ov02c10.c
+++ b/drivers/media/i2c/ov02c10.c
@@ -1511,6 +1511,9 @@ static int ov02c10_identify_module(struct ov02c10 *ov02c10)
 	if (ret)
 		return ret;
 
+	if (val == 0)
+		return -EPROBE_DEFER;
+
 	if (val != OV02C10_CHIP_ID) {
 		dev_err(&client->dev, "chip id mismatch: %x!=%x",
 			OV02C10_CHIP_ID, val);


### PR DESCRIPTION
The chip id may be zero while the resource is not ready. Put the driver to probe defer for retry.