### PR TITLE
IPU6 makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ version_lt = $(shell \
 KV_IVSC := 6.6.0
 KV_IPU_BRIDGE := 6.6.0
 KV_OV2740 := 6.8.0
+KV_OV01A10 := 6.8.0
 KV_OV05C10 := 6.8.0
 KV_HI556 := 6.10.0
 KV_IPU6_ISYS := 6.10.0
@@ -84,7 +85,6 @@ endif
 
 export CONFIG_ICAMERA_HM11B1 = m
 export CONFIG_ICAMERA_OV01A1S = m
-export CONFIG_ICAMERA_OV01A10 = m
 export CONFIG_ICAMERA_OV02C10 = m
 export CONFIG_ICAMERA_OV02E10 = m
 export CONFIG_ICAMERA_HM2170 = m
@@ -93,6 +93,10 @@ export CONFIG_ICAMERA_GC5035 = m
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
 export CONFIG_ICAMERA_OV2740 = m
+endif
+
+ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV01A10)),true)
+export CONFIG_ICAMERA_OV01A10 = m
 endif
 
 # Note OV05C10 check is reversed, it is not build on too old kernels

--- a/Makefile
+++ b/Makefile
@@ -81,22 +81,22 @@ else
 obj-y += drivers/media/pci/intel/ipu6/psys/
 endif
 
-export CONFIG_VIDEO_HM11B1 = m
-export CONFIG_VIDEO_OV01A1S = m
-export CONFIG_VIDEO_OV01A10 = m
-export CONFIG_VIDEO_OV02C10 = m
-export CONFIG_VIDEO_OV02E10 = m
-export CONFIG_VIDEO_HM2170 = m
-export CONFIG_VIDEO_HM2172 = m
-export CONFIG_VIDEO_HI556 = m
+export CONFIG_ICAMERA_HM11B1 = m
+export CONFIG_ICAMERA_OV01A1S = m
+export CONFIG_ICAMERA_OV01A10 = m
+export CONFIG_ICAMERA_OV02C10 = m
+export CONFIG_ICAMERA_OV02E10 = m
+export CONFIG_ICAMERA_HM2170 = m
+export CONFIG_ICAMERA_HM2172 = m
+export CONFIG_ICAMERA_HI556 = m
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
-export CONFIG_VIDEO_OV2740 = m
-export CONFIG_VIDEO_GC5035 = m
+export CONFIG_ICAMERA_OV2740 = m
+export CONFIG_ICAMERA_GC5035 = m
 endif
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV05C10)),false)
-export CONFIG_VIDEO_OV05C10 = m
+export CONFIG_ICAMERA_OV05C10 = m
 endif
 
 obj-y += drivers/media/i2c/

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,10 @@ export CONFIG_ICAMERA_OV02E10 = m
 export CONFIG_ICAMERA_HM2170 = m
 export CONFIG_ICAMERA_HM2172 = m
 export CONFIG_ICAMERA_HI556 = m
+export CONFIG_ICAMERA_GC5035 = m
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
 export CONFIG_ICAMERA_OV2740 = m
-export CONFIG_ICAMERA_GC5035 = m
 endif
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV05C10)),false)

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ KV_IVSC := 6.6.0
 KV_IPU_BRIDGE := 6.6.0
 KV_OV2740 := 6.8.0
 KV_OV05C10 := 6.8.0
+KV_HI556 := 6.10.0
 KV_IPU6_ISYS := 6.10.0
 
 KERNEL_SRC ?= /lib/modules/$(KERNELRELEASE)/build
@@ -88,15 +89,19 @@ export CONFIG_ICAMERA_OV02C10 = m
 export CONFIG_ICAMERA_OV02E10 = m
 export CONFIG_ICAMERA_HM2170 = m
 export CONFIG_ICAMERA_HM2172 = m
-export CONFIG_ICAMERA_HI556 = m
 export CONFIG_ICAMERA_GC5035 = m
 
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
 export CONFIG_ICAMERA_OV2740 = m
 endif
 
+# Note OV05C10 check is reversed, it is not build on too old kernels
 ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV05C10)),false)
 export CONFIG_ICAMERA_OV05C10 = m
+endif
+
+ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_HI556)),true)
+export CONFIG_ICAMERA_HI556 = m
 endif
 
 obj-y += drivers/media/i2c/

--- a/dkms.conf
+++ b/dkms.conf
@@ -34,6 +34,7 @@ KERNEL_VERSION=$(echo ${kernelver} | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 KV_IVSC=6.6.0
 KV_OV2740=6.8.0
 KV_OV05C10=6.8.0
+KV_HI556=6.10.0
 KV_IPU6_ISYS=6.10.0
 
 BUILT_MODULE_NAME[0]="hm11b1"
@@ -64,30 +65,32 @@ BUILT_MODULE_NAME[6]="hm2172"
 BUILT_MODULE_LOCATION[6]="drivers/media/i2c"
 DEST_MODULE_LOCATION[6]="/updates"
 
-BUILT_MODULE_NAME[7]="hi556"
-BUILT_MODULE_LOCATION[7]="drivers/media/i2c"
-DEST_MODULE_LOCATION[7]="/updates"
-
 if ! version_lt ${KERNEL_VERSION} ${KV_OV05C10}; then
     BUILD_EXCLUSIVE_CONFIG="CONFIG_VIDEO_V4L2_I2C CONFIG_V4L2_CCI_I2C"
-    BUILT_MODULE_NAME[8]="ov05c10"
-    BUILT_MODULE_LOCATION[8]="drivers/media/i2c"
-    DEST_MODULE_LOCATION[8]="/updates"
+    BUILT_MODULE_NAME[7]="ov05c10"
+    BUILT_MODULE_LOCATION[7]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[7]="/updates"
 fi
 
 if version_lt ${KERNEL_VERSION} ${KV_OV2740}; then
-    BUILT_MODULE_NAME[8]="ov2740"
-    BUILT_MODULE_LOCATION[8]="drivers/media/i2c"
-    DEST_MODULE_LOCATION[8]="/updates"
+    BUILT_MODULE_NAME[7]="ov2740"
+    BUILT_MODULE_LOCATION[7]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[7]="/updates"
 fi
 
 if ! version_lt ${KERNEL_VERSION} ${KV_IPU6_ISYS}; then
     PATCH[0]="0001-v6.10-IPU6-headers-used-by-PSYS.patch"
 fi
 
-BUILT_MODULE_NAME[9]="intel-ipu6-psys"
-BUILT_MODULE_LOCATION[9]="drivers/media/pci/intel/ipu6/psys"
-DEST_MODULE_LOCATION[9]="/updates"
+BUILT_MODULE_NAME[8]="intel-ipu6-psys"
+BUILT_MODULE_LOCATION[8]="drivers/media/pci/intel/ipu6/psys"
+DEST_MODULE_LOCATION[8]="/updates"
+
+if version_lt ${KERNEL_VERSION} ${KV_HI556}; then
+    BUILT_MODULE_NAME[9]="hi556"
+    BUILT_MODULE_LOCATION[9]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[9]="/updates"
+fi
 
 if version_lt ${KERNEL_VERSION} ${KV_IPU6_ISYS}; then
     BUILT_MODULE_NAME[10]="intel-ipu6"

--- a/dkms.conf
+++ b/dkms.conf
@@ -33,6 +33,7 @@ version_lt() {
 KERNEL_VERSION=$(echo ${kernelver} | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 KV_IVSC=6.6.0
 KV_OV2740=6.8.0
+KV_OV01A10=6.8.0
 KV_OV05C10=6.8.0
 KV_HI556=6.10.0
 KV_IPU6_ISYS=6.10.0
@@ -45,60 +46,62 @@ BUILT_MODULE_NAME[1]="ov01a1s"
 BUILT_MODULE_LOCATION[1]="drivers/media/i2c"
 DEST_MODULE_LOCATION[1]="/updates"
 
-BUILT_MODULE_NAME[2]="ov01a10"
+BUILT_MODULE_NAME[2]="ov02c10"
 BUILT_MODULE_LOCATION[2]="drivers/media/i2c"
 DEST_MODULE_LOCATION[2]="/updates"
 
-BUILT_MODULE_NAME[3]="ov02c10"
+BUILT_MODULE_NAME[3]="ov02e10"
 BUILT_MODULE_LOCATION[3]="drivers/media/i2c"
 DEST_MODULE_LOCATION[3]="/updates"
 
-BUILT_MODULE_NAME[4]="ov02e10"
+BUILT_MODULE_NAME[4]="hm2170"
 BUILT_MODULE_LOCATION[4]="drivers/media/i2c"
 DEST_MODULE_LOCATION[4]="/updates"
 
-BUILT_MODULE_NAME[5]="hm2170"
+BUILT_MODULE_NAME[5]="hm2172"
 BUILT_MODULE_LOCATION[5]="drivers/media/i2c"
 DEST_MODULE_LOCATION[5]="/updates"
 
-BUILT_MODULE_NAME[6]="hm2172"
-BUILT_MODULE_LOCATION[6]="drivers/media/i2c"
-DEST_MODULE_LOCATION[6]="/updates"
-
 if ! version_lt ${KERNEL_VERSION} ${KV_OV05C10}; then
     BUILD_EXCLUSIVE_CONFIG="CONFIG_VIDEO_V4L2_I2C CONFIG_V4L2_CCI_I2C"
-    BUILT_MODULE_NAME[7]="ov05c10"
-    BUILT_MODULE_LOCATION[7]="drivers/media/i2c"
-    DEST_MODULE_LOCATION[7]="/updates"
+    BUILT_MODULE_NAME[6]="ov05c10"
+    BUILT_MODULE_LOCATION[6]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[6]="/updates"
 fi
 
 if version_lt ${KERNEL_VERSION} ${KV_OV2740}; then
-    BUILT_MODULE_NAME[7]="ov2740"
-    BUILT_MODULE_LOCATION[7]="drivers/media/i2c"
-    DEST_MODULE_LOCATION[7]="/updates"
+    BUILT_MODULE_NAME[6]="ov2740"
+    BUILT_MODULE_LOCATION[6]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[6]="/updates"
 fi
 
 if ! version_lt ${KERNEL_VERSION} ${KV_IPU6_ISYS}; then
     PATCH[0]="0001-v6.10-IPU6-headers-used-by-PSYS.patch"
 fi
 
-BUILT_MODULE_NAME[8]="intel-ipu6-psys"
-BUILT_MODULE_LOCATION[8]="drivers/media/pci/intel/ipu6/psys"
-DEST_MODULE_LOCATION[8]="/updates"
+BUILT_MODULE_NAME[7]="intel-ipu6-psys"
+BUILT_MODULE_LOCATION[7]="drivers/media/pci/intel/ipu6/psys"
+DEST_MODULE_LOCATION[7]="/updates"
 
 if version_lt ${KERNEL_VERSION} ${KV_HI556}; then
-    BUILT_MODULE_NAME[9]="hi556"
-    BUILT_MODULE_LOCATION[9]="drivers/media/i2c"
-    DEST_MODULE_LOCATION[9]="/updates"
+    BUILT_MODULE_NAME[8]="hi556"
+    BUILT_MODULE_LOCATION[8]="drivers/media/i2c"
+    DEST_MODULE_LOCATION[8]="/updates"
 fi
 
 if version_lt ${KERNEL_VERSION} ${KV_IPU6_ISYS}; then
-    BUILT_MODULE_NAME[10]="intel-ipu6"
+    BUILT_MODULE_NAME[9]="intel-ipu6"
+    BUILT_MODULE_LOCATION[9]="drivers/media/pci/intel/ipu6"
+    DEST_MODULE_LOCATION[9]="/updates"
+
+    BUILT_MODULE_NAME[10]="intel-ipu6-isys"
     BUILT_MODULE_LOCATION[10]="drivers/media/pci/intel/ipu6"
     DEST_MODULE_LOCATION[10]="/updates"
+fi
 
-    BUILT_MODULE_NAME[11]="intel-ipu6-isys"
-    BUILT_MODULE_LOCATION[11]="drivers/media/pci/intel/ipu6"
+if version_lt ${KERNEL_VERSION} ${KV_OV01A10}; then
+    BUILT_MODULE_NAME[11]="ov01a10"
+    BUILT_MODULE_LOCATION[11]="drivers/media/i2c"
     DEST_MODULE_LOCATION[11]="/updates"
 fi
 

--- a/drivers/media/i2c/Makefile
+++ b/drivers/media/i2c/Makefile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (c) 2021 Intel Corporation.
 
-obj-$(CONFIG_VIDEO_HM11B1) += hm11b1.o
-obj-$(CONFIG_VIDEO_GC5035) += gc5035.o
-obj-$(CONFIG_VIDEO_OV01A1S) += ov01a1s.o
-obj-$(CONFIG_VIDEO_OV01A10) += ov01a10.o
-obj-$(CONFIG_VIDEO_OV02C10) += ov02c10.o
-obj-$(CONFIG_VIDEO_OV02E10) += ov02e10.o
-obj-$(CONFIG_VIDEO_OV05C10) += ov05c10.o
-obj-$(CONFIG_VIDEO_OV2740) += ov2740.o
-obj-$(CONFIG_VIDEO_HM2170) += hm2170.o
-obj-$(CONFIG_VIDEO_HM2170) += hm2172.o
-obj-$(CONFIG_VIDEO_HI556) += hi556.o
+obj-$(CONFIG_ICAMERA_HM11B1) += hm11b1.o
+obj-$(CONFIG_ICAMERA_GC5035) += gc5035.o
+obj-$(CONFIG_ICAMERA_OV01A1S) += ov01a1s.o
+obj-$(CONFIG_ICAMERA_OV01A10) += ov01a10.o
+obj-$(CONFIG_ICAMERA_OV02C10) += ov02c10.o
+obj-$(CONFIG_ICAMERA_OV02E10) += ov02e10.o
+obj-$(CONFIG_ICAMERA_OV05C10) += ov05c10.o
+obj-$(CONFIG_ICAMERA_OV2740) += ov2740.o
+obj-$(CONFIG_ICAMERA_HM2170) += hm2170.o
+obj-$(CONFIG_ICAMERA_HM2170) += hm2172.o
+obj-$(CONFIG_ICAMERA_HI556) += hi556.o
 obj-$(CONFIG_POWER_CTRL_LOGIC) += power_ctrl_logic.o

--- a/drivers/media/i2c/gc5035.c
+++ b/drivers/media/i2c/gc5035.c
@@ -1497,7 +1497,11 @@ static int gc5035_set_fmt(struct v4l2_subdev *sd,
 
 	mutex_lock(&gc5035->mutex);
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 		*v4l2_subdev_get_try_format(sd, sd_state, fmt->pad) = fmt->format;
+#else
+		*v4l2_subdev_state_get_format(sd_state, fmt->pad) = fmt->format;
+#endif
 	} else {
 		gc5035->cur_mode = mode;
 		h_blank = mode->hts_def - mode->width;
@@ -1522,7 +1526,11 @@ static int gc5035_get_fmt(struct v4l2_subdev *sd,
 
 	mutex_lock(&gc5035->mutex);
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 		fmt->format = *v4l2_subdev_get_try_format(sd, sd_state, fmt->pad);
+#else
+		fmt->format = *v4l2_subdev_state_get_format(sd_state, fmt->pad);
+#endif
 	} else {
 		fmt->format.width = mode->width;
 		fmt->format.height = mode->height;
@@ -1714,7 +1722,9 @@ static const struct v4l2_subdev_video_ops gc5035_video_ops = {
 };
 
 static const struct v4l2_subdev_pad_ops gc5035_pad_ops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
 	.init_cfg = gc5035_entity_init_cfg,
+#endif
 	.enum_mbus_code = gc5035_enum_mbus_code,
 	.enum_frame_size = gc5035_enum_frame_sizes,
 	.get_fmt = gc5035_get_fmt,
@@ -1729,6 +1739,12 @@ static const struct v4l2_subdev_ops gc5035_subdev_ops = {
 static const struct media_entity_operations gc5035_subdev_entity_ops = {
 	.link_validate = v4l2_subdev_link_validate,
 };
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+static const struct v4l2_subdev_internal_ops gc5035_internal_ops = {
+	.init_state = gc5035_entity_init_cfg,
+};
+#endif
 
 static int gc5035_set_exposure(struct gc5035 *gc5035, u32 val)
 {
@@ -2091,6 +2107,9 @@ static int gc5035_probe(struct i2c_client *client)
 	mutex_init(&gc5035->mutex);
 	sd = &gc5035->subdev;
 	v4l2_i2c_subdev_init(sd, client, &gc5035_subdev_ops);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+	sd->internal_ops = &gc5035_internal_ops;
+#endif
 	ret = gc5035_initialize_controls(gc5035);
 	if (ret) {
 		dev_err_probe(dev, ret, "Failed to initialize controls\n");


### PR DESCRIPTION
Here is a set with 4 Makefile improvements:

- Makefile: Switch sensor driver symbols from CONFIG_VIDEO_FOO to CONFIG_ICAMERA_FOO
- Makefile: Re-enable gc5035 compilation with kernels >= 6.8
- Makefile: Do not build hi556 driver with kernels >= 6.10
- Makefile: Do not build ov01a10 driver with kernels >= 6.8
