### PR TITLE
ipu6-psys: Adjust DMA code for ipu6-bus DMA changes in kernels >= 6.12

### DIFF
--- a/drivers/media/pci/intel/ipu6/psys/ipu-psys.h
+++ b/drivers/media/pci/intel/ipu6/psys/ipu-psys.h
@@ -15,6 +15,9 @@
 #include "ipu6.h"
 #include "ipu6-bus.h"
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 5)
+#include "ipu6-dma.h"
+#endif
 #include "ipu-fw-psys.h"
 #include "ipu-platform-psys.h"
 

--- a/drivers/media/pci/intel/ipu6/psys/ipu6-ppg.c
+++ b/drivers/media/pci/intel/ipu6/psys/ipu6-ppg.c
@@ -75,8 +75,11 @@ __get_buf_set(struct ipu_psys_fh *fh, size_t buf_set_size)
 	kbuf_set->kaddr = dma_alloc_attrs(&fh->psys->adev->dev,
 					  buf_set_size, &kbuf_set->dma_addr,
 					  GFP_KERNEL, 0);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 5)
 	kbuf_set->kaddr = dma_alloc_attrs(dev, buf_set_size,
+					  &kbuf_set->dma_addr, GFP_KERNEL, 0);
+#else
+	kbuf_set->kaddr = ipu6_dma_alloc(to_ipu6_bus_device(dev), buf_set_size,
 					  &kbuf_set->dma_addr, GFP_KERNEL, 0);
 #endif
 	if (!kbuf_set->kaddr) {

--- a/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
+++ b/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
@@ -1195,6 +1195,61 @@ index 000000000..92e3c3414
 +			int pkg_dir_idx, void __iomem *base, u64 *pkg_dir,
 +			dma_addr_t pkg_dir_dma_addr);
 +#endif /* IPU6_H */
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-dma.h b/drivers/media/pci/intel/ipu6/ipu6-dma.h
+new file mode 100644
+index 000000000..b51244add
+--- /dev/null
++++ b/drivers/media/pci/intel/ipu6/ipu6-dma.h
+@@ -0,0 +1,49 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/* Copyright (C) 2013--2024 Intel Corporation */
++
++#ifndef IPU6_DMA_H
++#define IPU6_DMA_H
++
++#include <linux/dma-map-ops.h>
++#include <linux/dma-mapping.h>
++#include <linux/iova.h>
++#include <linux/iova.h>
++#include <linux/scatterlist.h>
++#include <linux/types.h>
++
++#include "ipu6-bus.h"
++
++struct ipu6_mmu_info;
++
++struct ipu6_dma_mapping {
++	struct ipu6_mmu_info *mmu_info;
++	struct iova_domain iovad;
++};
++
++void ipu6_dma_sync_single(struct ipu6_bus_device *sys, dma_addr_t dma_handle,
++			  size_t size);
++void ipu6_dma_sync_sg(struct ipu6_bus_device *sys, struct scatterlist *sglist,
++		      int nents);
++void ipu6_dma_sync_sgtable(struct ipu6_bus_device *sys, struct sg_table *sgt);
++void *ipu6_dma_alloc(struct ipu6_bus_device *sys, size_t size,
++		     dma_addr_t *dma_handle, gfp_t gfp,
++		     unsigned long attrs);
++void ipu6_dma_free(struct ipu6_bus_device *sys, size_t size, void *vaddr,
++		   dma_addr_t dma_handle, unsigned long attrs);
++int ipu6_dma_mmap(struct ipu6_bus_device *sys, struct vm_area_struct *vma,
++		  void *addr, dma_addr_t iova, size_t size,
++		  unsigned long attrs);
++int ipu6_dma_map_sg(struct ipu6_bus_device *sys, struct scatterlist *sglist,
++		    int nents, enum dma_data_direction dir,
++		    unsigned long attrs);
++void ipu6_dma_unmap_sg(struct ipu6_bus_device *sys, struct scatterlist *sglist,
++		       int nents, enum dma_data_direction dir,
++		       unsigned long attrs);
++int ipu6_dma_map_sgtable(struct ipu6_bus_device *sys, struct sg_table *sgt,
++			 enum dma_data_direction dir, unsigned long attrs);
++void ipu6_dma_unmap_sgtable(struct ipu6_bus_device *sys, struct sg_table *sgt,
++			    enum dma_data_direction dir, unsigned long attrs);
++int ipu6_dma_get_sgtable(struct ipu6_bus_device *sys, struct sg_table *sgt,
++			 void *cpu_addr, dma_addr_t handle, size_t size,
++			 unsigned long attrs);
++#endif /* IPU6_DMA_H */
 -- 
 2.43.0
 


### PR DESCRIPTION
Upstream commit daabc5c64703 ("media: ipu6: not override the dma_ops of device in driver") has changed the ipu6-bus code to no longer modify the aux device's dma_ops, instead new ipu6_dma_*() helpers were introduced modify the psys driver to use these new helpers.

This fixes a DMA WARN_ON() triggering, which was followed by ipu6_psys_probe() failing due to dma_alloc_attrs() failing.

Cc: @vicamo @bingbucao 