### PR TITLE
ARL MR2, TWL MR1, ASL MR4 releases on kernel 6.12 Ubuntu 24.04 (iot)

### DIFF
--- a/drivers/media/pci/intel/ipu6/psys/ipu-psys.h
+++ b/drivers/media/pci/intel/ipu6/psys/ipu-psys.h
@@ -10,7 +10,6 @@
 #include <linux/version.h>
 #include "ipu6.h"
 #include "ipu6-bus.h"
-#include "ipu6-dma.h"
 #include "ipu-fw-psys.h"
 #include "ipu-platform-psys.h"
 

--- a/drivers/media/pci/intel/ipu6/psys/ipu6-ppg.c
+++ b/drivers/media/pci/intel/ipu6/psys/ipu6-ppg.c
@@ -6,7 +6,6 @@
 #include <linux/module.h>
 #include <linux/pm_runtime.h>
 
-#include "ipu6-dma.h"
 #include "ipu6-ppg.h"
 
 static bool enable_suspend_resume;
@@ -49,7 +48,7 @@ struct ipu_psys_kcmd *ipu_psys_ppg_get_stop_kcmd(struct ipu_psys_ppg *kppg)
 static struct ipu_psys_buffer_set *
 __get_buf_set(struct ipu_psys_fh *fh, size_t buf_set_size)
 {
-	struct ipu6_bus_device *adev = fh->psys->adev;
+	struct device *dev = &fh->psys->adev->auxdev.dev;
 	struct ipu_psys_buffer_set *kbuf_set;
 	struct ipu_psys_scheduler *sched = &fh->sched;
 
@@ -69,8 +68,8 @@ __get_buf_set(struct ipu_psys_fh *fh, size_t buf_set_size)
 	if (!kbuf_set)
 		return NULL;
 
-	kbuf_set->kaddr = ipu6_dma_alloc(adev, buf_set_size,
-					 &kbuf_set->dma_addr, GFP_KERNEL, 0);
+	kbuf_set->kaddr = dma_alloc_attrs(dev, buf_set_size,
+					  &kbuf_set->dma_addr, GFP_KERNEL, 0);
 	if (!kbuf_set->kaddr) {
 		kfree(kbuf_set);
 		return NULL;
@@ -112,7 +111,6 @@ ipu_psys_create_buffer_set(struct ipu_psys_kcmd *kcmd,
 					    kbuf_set->dma_addr);
 	keb = kcmd->kernel_enable_bitmap;
 	ipu_fw_psys_ppg_buffer_set_set_keb(kbuf_set->buf_set, keb);
-	ipu6_dma_sync_single(psys->adev, kbuf_set->dma_addr, buf_set_size);
 
 	return kbuf_set;
 }

--- a/kernel_patches/patch_6.12_mainline/0015-lt6911-2-pads-linked-to-ipu-2-ports-for-split-mode.patch
+++ b/kernel_patches/patch_6.12_mainline/0015-lt6911-2-pads-linked-to-ipu-2-ports-for-split-mode.patch
@@ -263,7 +263,7 @@ index ee884a8221fb..665e0e1a133a 100644
 +		struct fwnode_endpoint fwnode_ep = { 0 };
 +		int ret_ep;
 +		ret_ep = fwnode_graph_parse_endpoint(match->fwnode, &fwnode_ep);
-+		if (ret_ep >=0) {
++		if (ret_ep >= 0) {
 +			match->src_pad = fwnode_ep.port;
 +		} else {
 +			match->src_pad = -1;
@@ -334,4 +334,3 @@ index f26c323e9c96..3d1573a7bfab 100644
  /**
 --
 2.34.1
-

--- a/kernel_patches/patch_6.12_mainline/0016-media-i2c-add-dv_timings-api-in-lt6911uxe_for_ecg_kernel.patch
+++ b/kernel_patches/patch_6.12_mainline/0016-media-i2c-add-dv_timings-api-in-lt6911uxe_for_ecg_kernel.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] media: i2c: add dv_timings api in lt6911uxe
 
 and removed default cur_mode
 
+Signed-off-by: linya14x <linx.yang@intel.com>
 Signed-off-by: Dongcheng Yan <dongcheng.yan@intel.com>
 Signed-off-by: zouxiaoh <xiaohong.zou@intel.com>
 ---

--- a/kernel_patches/patch_6.12_mainline/0017-media-intel-ipu6-use-vc1-dma-for-MTL-and-ARL.patch
+++ b/kernel_patches/patch_6.12_mainline/0017-media-intel-ipu6-use-vc1-dma-for-MTL-and-ARL.patch
@@ -1,0 +1,42 @@
+From 68ca76a7fdd19de0ae142321958edf9c450b87c3 Mon Sep 17 00:00:00 2001
+From: Chen Meng J <meng.j.chen@intel.com>
+Date: Fri, 1 Nov 2024 16:41:42 +0800
+Subject: [PATCH] media: intel-ipu6: use vc1 dma for MTL and ARL
+
+Signed-off-by: Chen Meng J <meng.j.chen@intel.com>
+---
+ drivers/media/pci/intel/ipu6/ipu6-fw-isys.h    | 4 ++--
+ drivers/media/pci/intel/ipu6/ipu6-isys-video.c | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-fw-isys.h b/drivers/media/pci/intel/ipu6/ipu6-fw-isys.h
+index e6ee161bd058..545180c110cc 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-fw-isys.h
++++ b/drivers/media/pci/intel/ipu6/ipu6-fw-isys.h
+@@ -54,8 +54,8 @@ struct ipu6_isys;
+ /* Max number of planes for frame formats supported by the FW */
+ #define IPU6_PIN_PLANES_MAX 4
+
+-#define IPU6_FW_ISYS_SENSOR_TYPE_START 14
+-#define IPU6_FW_ISYS_SENSOR_TYPE_END 19
++#define IPU6_FW_ISYS_SENSOR_TYPE_START 1
++#define IPU6_FW_ISYS_SENSOR_TYPE_END 10
+ #define IPU6SE_FW_ISYS_SENSOR_TYPE_START 6
+ #define IPU6SE_FW_ISYS_SENSOR_TYPE_END 11
+ /*
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-isys-video.c b/drivers/media/pci/intel/ipu6/ipu6-isys-video.c
+index 9142280c299a..bde95c30c133 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-isys-video.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-isys-video.c
+@@ -529,7 +529,7 @@ static int ipu6_isys_fw_pin_cfg(struct ipu6_isys_video *av,
+ 	output_pin->csi_be_soc_pixel_remapping =
+ 		CSI_BE_SOC_PIXEL_REMAPPING_FLAG_NO_REMAPPING;
+
+-	output_pin->snoopable = true;
++	output_pin->snoopable = false;
+ 	output_pin->error_handling_enable = false;
+ 	output_pin->sensor_type = isys->sensor_type++;
+ 	if (isys->sensor_type > isys->pdata->ipdata->sensor_type_end)
+--
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0019-media-i2c-update-format-in-irq-for-lt6911uxe.patch
+++ b/kernel_patches/patch_6.12_mainline/0019-media-i2c-update-format-in-irq-for-lt6911uxe.patch
@@ -8,6 +8,7 @@ Subject: [PATCH] media: i2c: update format in irq for lt6911uxe
 - relpace lt6911uxe_get_fmt with v4l2_subdev_get_fmt
 - remove redundant log
 
+Signed-off-by: linya14x <linx.yang@intel.com>
 Signed-off-by: Dongcheng Yan <dongcheng.yan@intel.com>
 ---
  drivers/media/i2c/lt6911uxe.c | 21 +++++++++++++--------

--- a/kernel_patches/patch_6.12_mainline/0031-media-ipu-Dma-sync-at-buffer_prepare-callback-as-DMA.patch
+++ b/kernel_patches/patch_6.12_mainline/0031-media-ipu-Dma-sync-at-buffer_prepare-callback-as-DMA.patch
@@ -1,0 +1,41 @@
+From 01aa764775a0519dc13e4288556ffd737c3635d7 Mon Sep 17 00:00:00 2001
+From: linya14x <linx.yang@intel.com>
+Date: Wed, 23 Apr 2025 11:30:56 +0800
+Subject: [PATCH] media: ipu: Dma sync at buffer_prepare callback as DMA is
+ non-coherent
+
+Test Platform:
+MTL ARL LT6911UXE
+
+Signed-off-by: linya14x <linx.yang@intel.com>
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+---
+ drivers/media/pci/intel/ipu6/ipu6-isys-queue.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c b/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
+index 95e63a750b06..89b2b749fe59 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
+@@ -84,7 +84,9 @@ static int ipu6_isys_queue_setup(struct vb2_queue *q, unsigned int *num_buffers,
+ static int ipu6_isys_buf_prepare(struct vb2_buffer *vb)
+ {
+ 	struct ipu6_isys_queue *aq = vb2_queue_to_isys_queue(vb->vb2_queue);
++	struct ipu6_isys *isys = vb2_get_drv_priv(vb->vb2_queue);
+ 	struct ipu6_isys_video *av = ipu6_isys_queue_to_video(aq);
++	struct sg_table *sg = vb2_dma_sg_plane_desc(vb, 0);
+ 	struct device *dev = &av->isys->adev->auxdev.dev;
+ 	u32 bytesperline = ipu6_isys_get_bytes_per_line(av);
+ 	u32 height = ipu6_isys_get_frame_height(av);
+@@ -98,6 +100,9 @@ static int ipu6_isys_buf_prepare(struct vb2_buffer *vb)
+
+ 	vb2_set_plane_payload(vb, 0, bytesperline * height);
+
++	/* assume IPU is not DMA coherent */
++	ipu6_dma_sync_sgtable(isys->adev, sg);
++
+ 	return 0;
+ }
+
+--
+2.43.0

--- a/kernel_patches/patch_6.12_mainline/0032-Support-IPU6-ISYS-FW-trace-dump-for-upstream-driver.patch
+++ b/kernel_patches/patch_6.12_mainline/0032-Support-IPU6-ISYS-FW-trace-dump-for-upstream-driver.patch
@@ -1,0 +1,1430 @@
+From 2314aed424897031ab1abbfc3554bc4f19064007 Mon Sep 17 00:00:00 2001
+From: hepengpx <pengpengx.he@intel.com>
+Date: Fri, 25 Apr 2025 09:43:04 +0800
+Subject: [PATCH] Support IPU6 ISYS FW trace dump for upstream driver
+
+Signed-off-by: hepengpx <pengpengx.he@intel.com>
+---
+ drivers/media/pci/intel/ipu6/Makefile         |   3 +-
+ drivers/media/pci/intel/ipu6/ipu6-bus.h       |   2 +
+ drivers/media/pci/intel/ipu6/ipu6-fw-com.c    |  12 +-
+ drivers/media/pci/intel/ipu6/ipu6-isys.c      |  58 +-
+ .../media/pci/intel/ipu6/ipu6-platform-regs.h |  40 +
+ drivers/media/pci/intel/ipu6/ipu6-trace.c     | 896 ++++++++++++++++++
+ drivers/media/pci/intel/ipu6/ipu6-trace.h     | 147 +++
+ drivers/media/pci/intel/ipu6/ipu6.c           |  48 +
+ drivers/media/pci/intel/ipu6/ipu6.h           |   5 +
+ 9 files changed, 1206 insertions(+), 5 deletions(-)
+ create mode 100644 drivers/media/pci/intel/ipu6/ipu6-trace.c
+ create mode 100644 drivers/media/pci/intel/ipu6/ipu6-trace.h
+
+diff --git a/drivers/media/pci/intel/ipu6/Makefile b/drivers/media/pci/intel/ipu6/Makefile
+index 3af3264231e7..192927244db0 100644
+--- a/drivers/media/pci/intel/ipu6/Makefile
++++ b/drivers/media/pci/intel/ipu6/Makefile
+@@ -6,7 +6,8 @@ intel-ipu6-y			:= ipu6.o \
+ 				ipu6-mmu.o \
+ 				ipu6-buttress.o \
+ 				ipu6-cpd.o \
+-				ipu6-fw-com.o
++				ipu6-fw-com.o \
++				ipu6-trace.o
+
+ obj-$(CONFIG_VIDEO_INTEL_IPU6)	+= intel-ipu6.o
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-bus.h b/drivers/media/pci/intel/ipu6/ipu6-bus.h
+index bb4926dfdf08..c2a3f2293793 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-bus.h
++++ b/drivers/media/pci/intel/ipu6/ipu6-bus.h
+@@ -18,6 +18,7 @@ struct pci_dev;
+ #define IPU6_BUS_NAME	IPU6_NAME "-bus"
+
+ struct ipu6_buttress_ctrl;
++struct ipu_subsystem_trace_config;
+
+ struct ipu6_bus_device {
+ 	struct auxiliary_device auxdev;
+@@ -27,6 +28,7 @@ struct ipu6_bus_device {
+ 	void *pdata;
+ 	struct ipu6_mmu *mmu;
+ 	struct ipu6_device *isp;
++	struct ipu_subsystem_trace_config *trace_cfg;
+ 	struct ipu6_buttress_ctrl *ctrl;
+ 	u64 dma_mask;
+ 	const struct firmware *fw;
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-fw-com.c b/drivers/media/pci/intel/ipu6/ipu6-fw-com.c
+index 7d3d9314cb30..45738f3582a1 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-fw-com.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-fw-com.c
+@@ -14,6 +14,7 @@
+ #include "ipu6-bus.h"
+ #include "ipu6-dma.h"
+ #include "ipu6-fw-com.h"
++#include "ipu6-trace.h"
+
+ /*
+  * FWCOM layer is a shared resource between FW and driver. It consist
+@@ -265,8 +266,15 @@ EXPORT_SYMBOL_NS_GPL(ipu6_fw_com_prepare, INTEL_IPU6);
+
+ int ipu6_fw_com_open(struct ipu6_fw_com_context *ctx)
+ {
+-	/* write magic pattern to disable the tunit trace */
+-	writel(TUNIT_MAGIC_PATTERN, ctx->dmem_addr + TUNIT_CFG_DWR_REG * 4);
++	dma_addr_t trace_buff = TUNIT_MAGIC_PATTERN;
++
++	/*
++	 * Write trace buff start addr to tunit cfg reg.
++	 * This feature is used to enable tunit trace in secure mode.
++	 */
++	ipu_trace_buffer_dma_handle(&ctx->adev->auxdev.dev, &trace_buff);
++	writel(trace_buff, ctx->dmem_addr + TUNIT_CFG_DWR_REG * 4);
++
+ 	/* Check if SP is in valid state */
+ 	if (!ctx->cell_ready(ctx->adev))
+ 		return -EIO;
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-isys.c b/drivers/media/pci/intel/ipu6/ipu6-isys.c
+index 2577d65f8305..1b73de464444 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-isys.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-isys.c
+@@ -41,6 +41,7 @@
+ #include "ipu6-platform-buttress-regs.h"
+ #include "ipu6-platform-isys-csi2-reg.h"
+ #include "ipu6-platform-regs.h"
++#include "ipu6-trace.h"
+
+ #define IPU6_BUTTRESS_FABIC_CONTROL		0x68
+ #define GDA_ENABLE_IWAKE_INDEX			2
+@@ -360,9 +361,11 @@ irqreturn_t isys_isr(struct ipu6_bus_device *adev)
+ 	u32 status_sw, status_csi;
+ 	u32 ctrl0_status, ctrl0_clear;
+
++	dev_dbg(&adev->auxdev.dev, "%s enter", __func__);
+ 	spin_lock(&isys->power_lock);
+ 	if (!isys->power) {
+ 		spin_unlock(&isys->power_lock);
++		dev_dbg(&adev->auxdev.dev, "%s exit, no power", __func__);
+ 		return IRQ_NONE;
+ 	}
+
+@@ -411,6 +414,7 @@ irqreturn_t isys_isr(struct ipu6_bus_device *adev)
+
+ 	spin_unlock(&isys->power_lock);
+
++	dev_dbg(&adev->auxdev.dev, "%s exit", __func__);
+ 	return IRQ_HANDLED;
+ }
+
+@@ -1054,6 +1058,46 @@ void ipu6_put_fw_msg_buf(struct ipu6_isys *isys, u64 data)
+ 	spin_unlock_irqrestore(&isys->listlock, flags);
+ }
+
++struct ipu_trace_block isys_trace_blocks[] = {
++	{
++		.offset = IPU_TRACE_REG_IS_TRACE_UNIT_BASE,
++		.type = IPU_TRACE_BLOCK_TUN,
++	},
++	{
++		.offset = IPU_TRACE_REG_IS_SP_EVQ_BASE,
++		.type = IPU_TRACE_BLOCK_TM,
++	},
++	{
++		.offset = IPU_TRACE_REG_IS_SP_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		.offset = IPU_TRACE_REG_IS_ISL_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		.offset = IPU_TRACE_REG_IS_MMU_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		/* Note! this covers all 8 blocks */
++		.offset = IPU_TRACE_REG_CSI2_TM_BASE(0),
++		.type = IPU_TRACE_CSI2,
++	},
++	{
++		/* Note! this covers all 11 blocks */
++		.offset = IPU_TRACE_REG_CSI2_PORT_SIG2SIO_GR_BASE(0),
++		.type = IPU_TRACE_SIG2CIOS,
++	},
++	{
++		.offset = IPU_TRACE_REG_IS_GPREG_TRACE_TIMER_RST_N,
++		.type = IPU_TRACE_TIMER_RST,
++	},
++	{
++		.type = IPU_TRACE_BLOCK_END,
++	}
++};
++
+ static int isys_probe(struct auxiliary_device *auxdev,
+ 		      const struct auxiliary_device_id *auxdev_id)
+ {
+@@ -1125,6 +1169,8 @@ static int isys_probe(struct auxiliary_device *auxdev,
+ 			goto remove_shared_buffer;
+ 	}
+
++	ipu_trace_init(adev->isp, isys->pdata->base, &auxdev->dev,
++		       isys_trace_blocks);
+ 	cpu_latency_qos_add_request(&isys->pm_qos, PM_QOS_DEFAULT_VALUE);
+
+ 	ret = alloc_fw_msg_bufs(isys, 20);
+@@ -1154,6 +1200,7 @@ static int isys_probe(struct auxiliary_device *auxdev,
+ free_fw_msg_bufs:
+ 	free_fw_msg_bufs(isys);
+ out_remove_pkg_dir_shared_buffer:
++	ipu_trace_uninit(&auxdev->dev);
+ 	cpu_latency_qos_remove_request(&isys->pm_qos);
+ 	if (!isp->secure_mode)
+ 		ipu6_cpd_free_pkg_dir(adev);
+@@ -1199,6 +1246,7 @@ static void isys_remove(struct auxiliary_device *auxdev)
+ 		mutex_destroy(&isys->streams[i].mutex);
+
+ 	isys_iwake_watermark_cleanup(isys);
++	ipu_trace_uninit(&auxdev->dev);
+ 	mutex_destroy(&isys->stream_mutex);
+ 	mutex_destroy(&isys->mutex);
+ #ifdef CONFIG_VIDEO_INTEL_IPU6_ISYS_RESET
+@@ -1251,12 +1299,17 @@ static int isys_isr_one(struct ipu6_bus_device *adev)
+ 	u32 index;
+ 	u64 ts;
+
+-	if (!isys->fwcom)
++	dev_dbg(&adev->auxdev.dev, "%s enter", __func__);
++	if (!isys->fwcom) {
++		dev_dbg(&adev->auxdev.dev, "%s exit, fwcom is null", __func__);
+ 		return 1;
++	}
+
+ 	resp = ipu6_fw_isys_get_resp(isys->fwcom, IPU6_BASE_MSG_RECV_QUEUES);
+-	if (!resp)
++	if (!resp) {
++		dev_dbg(&adev->auxdev.dev, "%s exit, resp is null", __func__);
+ 		return 1;
++	}
+
+ 	ts = (u64)resp->timestamp[1] << 32 | resp->timestamp[0];
+
+@@ -1365,6 +1418,7 @@ static int isys_isr_one(struct ipu6_bus_device *adev)
+ 	ipu6_isys_put_stream(stream);
+ leave:
+ 	ipu6_fw_isys_put_resp(isys->fwcom, IPU6_BASE_MSG_RECV_QUEUES);
++	dev_dbg(&adev->auxdev.dev, "%s exit", __func__);
+ 	return 0;
+ }
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-platform-regs.h b/drivers/media/pci/intel/ipu6/ipu6-platform-regs.h
+index b883385adb44..a1744d2434f4 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-platform-regs.h
++++ b/drivers/media/pci/intel/ipu6/ipu6-platform-regs.h
+@@ -176,4 +176,44 @@ enum nci_ab_access_mode {
+ #define IPU6_PSYS_GPDEV_IRQ_FWIRQ(n)		BIT(n)
+ #define IPU6_REG_PSYS_GPDEV_FWIRQ(n)		(4 * (n) + 0x1aa100)
+
++/* Trace unit related register definitions */
++#define TRACE_REG_MAX_ISYS_OFFSET       0xfffff
++#define TRACE_REG_MAX_PSYS_OFFSET       0xfffff
++#define IPU_ISYS_OFFSET                 IPU6_ISYS_DMEM_OFFSET
++#define IPU_PSYS_OFFSET                 IPU6_PSYS_DMEM_OFFSET
++/* ISYS trace unit registers */
++/* Trace unit base offset */
++#define IPU_TRACE_REG_IS_TRACE_UNIT_BASE                0x27d000
++/* Trace monitors */
++#define IPU_TRACE_REG_IS_SP_EVQ_BASE            0x211000
++/* GPC blocks */
++#define IPU_TRACE_REG_IS_SP_GPC_BASE            0x210800
++#define IPU_TRACE_REG_IS_ISL_GPC_BASE           0x2b0a00
++#define IPU_TRACE_REG_IS_MMU_GPC_BASE           0x2e0f00
++/* each CSI2 port has a dedicated trace monitor, index 0..7 */
++#define IPU_TRACE_REG_CSI2_TM_BASE(port)        (0x220400 + 0x1000 * (port))
++
++/* Trace timers */
++#define IPU_TRACE_REG_IS_GPREG_TRACE_TIMER_RST_N                0x27c410
++#define TRACE_REG_GPREG_TRACE_TIMER_RST_OFF             BIT(0)
++
++/* SIG2CIO */
++#define IPU_TRACE_REG_CSI2_PORT_SIG2SIO_GR_BASE(port)           \
++				(0x220e00 + (port) * 0x1000)
++
++/* PSYS trace unit registers */
++/* Trace unit base offset */
++#define IPU_TRACE_REG_PS_TRACE_UNIT_BASE                0x1b4000
++/* Trace monitors */
++#define IPU_TRACE_REG_PS_SPC_EVQ_BASE                   0x119000
++#define IPU_TRACE_REG_PS_SPP0_EVQ_BASE                  0x139000
++
++/* GPC blocks */
++#define IPU_TRACE_REG_PS_SPC_GPC_BASE                   0x118800
++#define IPU_TRACE_REG_PS_SPP0_GPC_BASE                  0x138800
++#define IPU_TRACE_REG_PS_MMU_GPC_BASE                   0x1b1b00
++
++/* Trace timers */
++#define IPU_TRACE_REG_PS_GPREG_TRACE_TIMER_RST_N        0x1aa714
++
+ #endif /* IPU6_PLATFORM_REGS_H */
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-trace.c b/drivers/media/pci/intel/ipu6/ipu6-trace.c
+new file mode 100644
+index 000000000000..f91bd88c787b
+--- /dev/null
++++ b/drivers/media/pci/intel/ipu6/ipu6-trace.c
+@@ -0,0 +1,896 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2014 - 2025 Intel Corporation
++
++#include <linux/version.h>
++#include <linux/debugfs.h>
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/dma-mapping.h>
++#include <linux/module.h>
++#include <linux/pm_runtime.h>
++#include <linux/sizes.h>
++#include <linux/uaccess.h>
++#include <linux/vmalloc.h>
++
++#include "ipu6.h"
++#include "ipu6-bus.h"
++#include "ipu6-platform-regs.h"
++#include "ipu6-dma.h"
++#include "ipu6-trace.h"
++
++/*
++ * enabling ipu trace need a 96 MB buffer.
++ */
++static bool ipu_trace_enable;
++module_param(ipu_trace_enable, bool, 0660);
++MODULE_PARM_DESC(ipu_trace_enable, "IPU trace enable");
++
++struct trace_register_range {
++	u32 start;
++	u32 end;
++};
++
++#define MEMORY_RING_BUFFER_SIZE		(SZ_1M * 96)
++#define TRACE_MESSAGE_SIZE		16
++/*
++ * It looks that the trace unit sometimes writes outside the given buffer.
++ * To avoid memory corruption one extra page is reserved at the end
++ * of the buffer. Read also the extra area since it may contain valid data.
++ */
++#define MEMORY_RING_BUFFER_GUARD	PAGE_SIZE
++#define MEMORY_RING_BUFFER_OVERREAD	MEMORY_RING_BUFFER_GUARD
++#define MAX_TRACE_REGISTERS		200
++#define TRACE_CONF_DUMP_BUFFER_SIZE	(MAX_TRACE_REGISTERS * 2 * 32)
++#define TRACE_CONF_DATA_MAX_LEN		(1024 * 4)
++#define WPT_TRACE_CONF_DATA_MAX_LEN	(1024 * 64)
++
++struct config_value {
++	u32 reg;
++	u32 value;
++};
++
++struct ipu_trace_buffer {
++	dma_addr_t dma_handle;
++	void *memory_buffer;
++};
++
++struct ipu_subsystem_wptrace_config {
++	bool open;
++	char *conf_dump_buffer;
++	int size_conf_dump;
++	unsigned int fill_level;
++	struct config_value config[MAX_TRACE_REGISTERS];
++};
++
++struct ipu_subsystem_trace_config {
++	u32 offset;
++	void __iomem *base;
++	struct ipu_trace_buffer memory;	/* ring buffer */
++	struct device *dev;
++	struct ipu_trace_block *blocks;
++	unsigned int fill_level;	/* Nbr of regs in config table below */
++	bool running;
++	/* Cached register values  */
++	struct config_value config[MAX_TRACE_REGISTERS];
++	/* watchpoint trace info */
++	struct ipu_subsystem_wptrace_config wpt;
++};
++
++struct ipu_trace {
++	struct mutex lock; /* Protect ipu trace operations */
++	bool open;
++	char *conf_dump_buffer;
++	int size_conf_dump;
++
++	struct ipu_subsystem_trace_config isys;
++	struct ipu_subsystem_trace_config psys;
++};
++
++static void __ipu_trace_restore(struct device *dev)
++{
++	struct ipu6_bus_device *adev = to_ipu6_bus_device(dev);
++	struct ipu6_device *isp = adev->isp;
++	struct ipu_trace *trace = isp->trace;
++	struct config_value *config;
++	struct ipu_subsystem_trace_config *sys = adev->trace_cfg;
++	struct ipu_trace_block *blocks;
++	u32 mapped_trace_buffer;
++	void __iomem *addr = NULL;
++	int i;
++
++	if (trace->open) {
++		dev_info(dev, "Trace control file open. Skipping update\n");
++		return;
++	}
++
++	if (!sys)
++		return;
++
++	/* leave if no trace configuration for this subsystem */
++	if (sys->fill_level == 0)
++		return;
++
++	/* Find trace unit base address */
++	blocks = sys->blocks;
++	while (blocks->type != IPU_TRACE_BLOCK_END) {
++		if (blocks->type == IPU_TRACE_BLOCK_TUN) {
++			addr = sys->base + blocks->offset;
++			break;
++		}
++		blocks++;
++	}
++	if (!addr)
++		return;
++
++	if (!sys->memory.memory_buffer) {
++		sys->memory.memory_buffer =
++		    ipu6_dma_alloc(adev, MEMORY_RING_BUFFER_SIZE +
++				       MEMORY_RING_BUFFER_GUARD,
++				       &sys->memory.dma_handle,
++				       GFP_KERNEL, 0);
++	}
++
++	if (!sys->memory.memory_buffer) {
++		dev_err(dev, "No memory for tracing. Trace unit disabled\n");
++		return;
++	}
++
++	config = sys->config;
++	mapped_trace_buffer = sys->memory.dma_handle;
++
++	/* ring buffer base */
++	writel(mapped_trace_buffer, addr + TRACE_REG_TUN_DRAM_BASE_ADDR);
++
++	/* ring buffer end */
++	writel(mapped_trace_buffer + MEMORY_RING_BUFFER_SIZE -
++		   TRACE_MESSAGE_SIZE, addr + TRACE_REG_TUN_DRAM_END_ADDR);
++
++	/* Infobits for ddr trace */
++	writel(IPU6_INFO_REQUEST_DESTINATION_PRIMARY,
++	       addr + TRACE_REG_TUN_DDR_INFO_VAL);
++
++	/* Find trace timer reset address */
++	addr = NULL;
++	blocks = sys->blocks;
++	while (blocks->type != IPU_TRACE_BLOCK_END) {
++		if (blocks->type == IPU_TRACE_TIMER_RST) {
++			addr = sys->base + blocks->offset;
++			break;
++		}
++		blocks++;
++	}
++	if (!addr) {
++		dev_err(dev, "No trace reset addr\n");
++		return;
++	}
++
++	/* Remove reset from trace timers */
++	writel(TRACE_REG_GPREG_TRACE_TIMER_RST_OFF, addr);
++
++	/* Register config received from userspace */
++	for (i = 0; i < sys->fill_level; i++) {
++		dev_dbg(dev,
++			"Trace restore: reg 0x%08x, value 0x%08x\n",
++			config[i].reg, config[i].value);
++		writel(config[i].value, isp->base + config[i].reg);
++	}
++
++	/* Register wpt config received from userspace, and only psys has wpt */
++	config = sys->wpt.config;
++	for (i = 0; i < sys->wpt.fill_level; i++) {
++		dev_dbg(dev, "Trace restore: reg 0x%08x, value 0x%08x\n",
++			config[i].reg, config[i].value);
++		writel(config[i].value, isp->base + config[i].reg);
++	}
++	sys->running = true;
++}
++
++void ipu_trace_restore(struct device *dev)
++{
++	struct ipu_trace *trace = to_ipu6_bus_device(dev)->isp->trace;
++
++	if (!trace)
++		return;
++
++	mutex_lock(&trace->lock);
++	__ipu_trace_restore(dev);
++	mutex_unlock(&trace->lock);
++}
++EXPORT_SYMBOL_GPL(ipu_trace_restore);
++
++static void __ipu_trace_stop(struct device *dev)
++{
++	struct ipu_subsystem_trace_config *sys =
++	    to_ipu6_bus_device(dev)->trace_cfg;
++	struct ipu_trace_block *blocks;
++
++	if (!sys)
++		return;
++
++	if (!sys->running)
++		return;
++	sys->running = false;
++
++	/* Turn off all the gpc blocks */
++	blocks = sys->blocks;
++	while (blocks->type != IPU_TRACE_BLOCK_END) {
++		if (blocks->type == IPU_TRACE_BLOCK_GPC) {
++			writel(0, sys->base + blocks->offset +
++				   TRACE_REG_GPC_OVERALL_ENABLE);
++		}
++		blocks++;
++	}
++
++	/* Turn off all the trace monitors */
++	blocks = sys->blocks;
++	while (blocks->type != IPU_TRACE_BLOCK_END) {
++		if (blocks->type == IPU_TRACE_BLOCK_TM) {
++			writel(0, sys->base + blocks->offset +
++				   TRACE_REG_TM_TRACE_ENABLE_NPK);
++
++			writel(0, sys->base + blocks->offset +
++				   TRACE_REG_TM_TRACE_ENABLE_DDR);
++		}
++		blocks++;
++	}
++
++	/* Turn off trace units */
++	blocks = sys->blocks;
++	while (blocks->type != IPU_TRACE_BLOCK_END) {
++		if (blocks->type == IPU_TRACE_BLOCK_TUN) {
++			writel(0, sys->base + blocks->offset +
++				   TRACE_REG_TUN_DDR_ENABLE);
++			writel(0, sys->base + blocks->offset +
++				   TRACE_REG_TUN_NPK_ENABLE);
++		}
++		blocks++;
++	}
++}
++
++void ipu_trace_stop(struct device *dev)
++{
++	struct ipu_trace *trace = to_ipu6_bus_device(dev)->isp->trace;
++
++	if (!trace)
++		return;
++
++	mutex_lock(&trace->lock);
++	__ipu_trace_stop(dev);
++	mutex_unlock(&trace->lock);
++}
++EXPORT_SYMBOL_GPL(ipu_trace_stop);
++
++static int update_register_cache(struct ipu6_device *isp, u32 reg, u32 value)
++{
++	struct ipu_trace *dctrl = isp->trace;
++	struct ipu_subsystem_trace_config *sys;
++	int rval = -EINVAL;
++
++	if (dctrl->isys.offset == dctrl->psys.offset) {
++		/* For the IPU with uniform address space */
++		if (reg >= IPU_ISYS_OFFSET &&
++		    reg < IPU_ISYS_OFFSET + TRACE_REG_MAX_ISYS_OFFSET)
++			sys = &dctrl->isys;
++		else if (reg >= IPU_PSYS_OFFSET &&
++			 reg < IPU_PSYS_OFFSET + TRACE_REG_MAX_PSYS_OFFSET)
++			sys = &dctrl->psys;
++		else
++			goto error;
++	} else {
++		if (dctrl->isys.offset &&
++		    reg >= dctrl->isys.offset &&
++		    reg < dctrl->isys.offset + TRACE_REG_MAX_ISYS_OFFSET)
++			sys = &dctrl->isys;
++		else if (dctrl->psys.offset &&
++			 reg >= dctrl->psys.offset &&
++			 reg < dctrl->psys.offset + TRACE_REG_MAX_PSYS_OFFSET)
++			sys = &dctrl->psys;
++		else
++			goto error;
++	}
++
++	if (sys->fill_level < MAX_TRACE_REGISTERS) {
++		dev_dbg(sys->dev,
++			"Trace reg addr 0x%08x value 0x%08x\n", reg, value);
++		sys->config[sys->fill_level].reg = reg;
++		sys->config[sys->fill_level].value = value;
++		sys->fill_level++;
++	} else {
++		rval = -ENOMEM;
++		goto error;
++	}
++	return 0;
++error:
++	dev_info(&isp->pdev->dev,
++		 "Trace register address 0x%08x ignored as invalid register\n",
++		 reg);
++	return rval;
++}
++
++static void traceconf_dump(struct ipu6_device *isp)
++{
++	struct ipu_subsystem_trace_config *sys[2] = {
++		&isp->trace->isys,
++		&isp->trace->psys
++	};
++	int i, j, rem_size;
++	char *out;
++
++	isp->trace->size_conf_dump = 0;
++	out = isp->trace->conf_dump_buffer;
++	rem_size = TRACE_CONF_DUMP_BUFFER_SIZE;
++
++	for (j = 0; j < ARRAY_SIZE(sys); j++) {
++		for (i = 0; i < sys[j]->fill_level && rem_size > 0; i++) {
++			int bytes_print;
++			int n = snprintf(out, rem_size, "0x%08x = 0x%08x\n",
++					 sys[j]->config[i].reg,
++					 sys[j]->config[i].value);
++
++			bytes_print = min(n, rem_size - 1);
++			rem_size -= bytes_print;
++			out += bytes_print;
++		}
++	}
++	isp->trace->size_conf_dump = out - isp->trace->conf_dump_buffer;
++}
++
++static void clear_trace_buffer(struct ipu_subsystem_trace_config *sys)
++{
++	if (!sys || !sys->memory.memory_buffer)
++		return;
++
++	memset(sys->memory.memory_buffer, 0, MEMORY_RING_BUFFER_SIZE +
++	       MEMORY_RING_BUFFER_OVERREAD);
++
++	dma_sync_single_for_device(sys->dev,
++				   sys->memory.dma_handle,
++				   MEMORY_RING_BUFFER_SIZE +
++				   MEMORY_RING_BUFFER_GUARD, DMA_FROM_DEVICE);
++}
++
++static int traceconf_open(struct inode *inode, struct file *file)
++{
++	int ret;
++	struct ipu6_device *isp;
++
++	if (!inode->i_private)
++		return -EACCES;
++
++	isp = inode->i_private;
++
++	ret = mutex_trylock(&isp->trace->lock);
++	if (!ret)
++		return -EBUSY;
++
++	if (isp->trace->open) {
++		mutex_unlock(&isp->trace->lock);
++		return -EBUSY;
++	}
++
++	file->private_data = isp;
++	isp->trace->open = 1;
++	if (file->f_mode & FMODE_WRITE) {
++		/* TBD: Allocate temp buffer for processing.
++		 * Push validated buffer to active config
++		 */
++
++		/* Forget old config if opened for write */
++		isp->trace->isys.fill_level = 0;
++		isp->trace->psys.fill_level = 0;
++		isp->trace->psys.wpt.fill_level = 0;
++	}
++
++	if (file->f_mode & FMODE_READ) {
++		isp->trace->conf_dump_buffer =
++		    vzalloc(TRACE_CONF_DUMP_BUFFER_SIZE);
++		if (!isp->trace->conf_dump_buffer) {
++			isp->trace->open = 0;
++			mutex_unlock(&isp->trace->lock);
++			return -ENOMEM;
++		}
++		traceconf_dump(isp);
++	}
++	mutex_unlock(&isp->trace->lock);
++	return 0;
++}
++
++static ssize_t traceconf_read(struct file *file, char __user *buf,
++			       size_t len, loff_t *ppos)
++{
++	struct ipu6_device *isp = file->private_data;
++
++	return simple_read_from_buffer(buf, len, ppos,
++				       isp->trace->conf_dump_buffer,
++				       isp->trace->size_conf_dump);
++}
++
++static ssize_t traceconf_write(struct file *file, const char __user *buf,
++				size_t len, loff_t *ppos)
++{
++	int i;
++	struct ipu6_device *isp = file->private_data;
++	ssize_t bytes = 0;
++	char *ipu_trace_buffer = NULL;
++	size_t buffer_size = 0;
++	u32 ipu_trace_number = 0;
++	struct config_value *cfg_buffer = NULL;
++
++	if ((*ppos < 0) || (len > TRACE_CONF_DATA_MAX_LEN) ||
++	    (len < sizeof(ipu_trace_number))) {
++		dev_info(&isp->pdev->dev,
++			 "length is error, len:%ld, loff:%lld\n",
++			 len, *ppos);
++		return -EINVAL;
++	}
++
++	ipu_trace_buffer = vzalloc(len);
++	if (!ipu_trace_buffer)
++		return -ENOMEM;
++
++	bytes = copy_from_user(ipu_trace_buffer, buf, len);
++	if (bytes != 0) {
++		vfree(ipu_trace_buffer);
++		return -EFAULT;
++	}
++
++	memcpy(&ipu_trace_number, ipu_trace_buffer, sizeof(u32));
++	buffer_size = ipu_trace_number * sizeof(struct config_value);
++	if ((buffer_size + sizeof(ipu_trace_number)) != len) {
++		dev_info(&isp->pdev->dev,
++			 "File size is not right, len:%ld, buffer_size:%zu\n",
++			 len, buffer_size);
++		vfree(ipu_trace_buffer);
++		return -EFAULT;
++	}
++
++	mutex_lock(&isp->trace->lock);
++	cfg_buffer = (struct config_value *)(ipu_trace_buffer + sizeof(u32));
++	for (i = 0; i < ipu_trace_number; i++) {
++		update_register_cache(isp, cfg_buffer[i].reg,
++				      cfg_buffer[i].value);
++	}
++	mutex_unlock(&isp->trace->lock);
++	vfree(ipu_trace_buffer);
++
++	return len;
++}
++
++static int traceconf_release(struct inode *inode, struct file *file)
++{
++	struct ipu6_device *isp = file->private_data;
++	struct device *psys_dev = isp->psys ? &isp->psys->auxdev.dev : NULL;
++	struct device *isys_dev = isp->isys ? &isp->isys->auxdev.dev : NULL;
++	int isys_pm_rval = -EINVAL;
++	int psys_pm_rval = -EINVAL;
++
++	/*
++	 * Turn devices on outside trace->lock mutex. PM transition may
++	 * cause call to function which tries to take the same lock.
++	 * Also do this before trace->open is set back to 0 to avoid
++	 * double restore (one here and one in pm transition). We can't
++	 * rely purely on the restore done by pm call backs since trace
++	 * configuration can occur in any phase compared to other activity.
++	 */
++
++	if (file->f_mode & FMODE_WRITE) {
++		if (isys_dev)
++			isys_pm_rval = pm_runtime_resume_and_get(isys_dev);
++		if (isys_pm_rval >= 0 && psys_dev)
++			psys_pm_rval = pm_runtime_resume_and_get(psys_dev);
++	}
++
++	mutex_lock(&isp->trace->lock);
++	isp->trace->open = 0;
++	vfree(isp->trace->conf_dump_buffer);
++	isp->trace->conf_dump_buffer = NULL;
++
++	/* Update new cfg to HW */
++	if (isys_pm_rval >= 0) {
++		__ipu_trace_stop(isys_dev);
++		clear_trace_buffer(isp->isys->trace_cfg);
++		__ipu_trace_restore(isys_dev);
++	}
++
++	if (psys_pm_rval >= 0) {
++		__ipu_trace_stop(psys_dev);
++		clear_trace_buffer(isp->psys->trace_cfg);
++		__ipu_trace_restore(psys_dev);
++	}
++	mutex_unlock(&isp->trace->lock);
++
++	if (psys_pm_rval >= 0)
++		pm_runtime_put(psys_dev);
++	if (isys_pm_rval >= 0)
++		pm_runtime_put(isys_dev);
++
++	return 0;
++}
++
++static const struct file_operations ipu_traceconf_fops = {
++	.owner = THIS_MODULE,
++	.open = traceconf_open,
++	.release = traceconf_release,
++	.read = traceconf_read,
++	.write = traceconf_write,
++	.llseek = noop_llseek,
++};
++
++static void wptraceconf_dump(struct ipu6_device *isp)
++{
++	struct ipu_subsystem_wptrace_config *sys = &isp->trace->psys.wpt;
++	int i, rem_size;
++	char *out;
++
++	sys->size_conf_dump = 0;
++	out = sys->conf_dump_buffer;
++	rem_size = TRACE_CONF_DUMP_BUFFER_SIZE;
++
++	for (i = 0; i < sys->fill_level && rem_size > 0; i++) {
++		int bytes_print;
++		int n = snprintf(out, rem_size, "0x%08x = 0x%08x\n",
++				 sys->config[i].reg,
++				 sys->config[i].value);
++
++		bytes_print = min(n, rem_size - 1);
++		rem_size -= bytes_print;
++		out += bytes_print;
++	}
++	sys->size_conf_dump = out - sys->conf_dump_buffer;
++}
++
++static int wptraceconf_open(struct inode *inode, struct file *file)
++{
++	int ret;
++	struct ipu6_device *isp;
++
++	if (!inode->i_private)
++		return -EACCES;
++
++	isp = inode->i_private;
++	ret = mutex_trylock(&isp->trace->lock);
++	if (!ret)
++		return -EBUSY;
++
++	if (isp->trace->psys.wpt.open) {
++		mutex_unlock(&isp->trace->lock);
++		return -EBUSY;
++	}
++
++	file->private_data = isp;
++	if (file->f_mode & FMODE_WRITE) {
++		/* TBD: Allocate temp buffer for processing.
++		 * Push validated buffer to active config
++		 */
++		/* Forget old config if opened for write */
++		isp->trace->psys.wpt.fill_level = 0;
++	}
++
++	if (file->f_mode & FMODE_READ) {
++		isp->trace->psys.wpt.conf_dump_buffer =
++		    vzalloc(TRACE_CONF_DUMP_BUFFER_SIZE);
++		if (!isp->trace->psys.wpt.conf_dump_buffer) {
++			mutex_unlock(&isp->trace->lock);
++			return -ENOMEM;
++		}
++		wptraceconf_dump(isp);
++	}
++	mutex_unlock(&isp->trace->lock);
++	return 0;
++}
++
++static ssize_t wptraceconf_read(struct file *file, char __user *buf,
++				 size_t len, loff_t *ppos)
++{
++	struct ipu6_device *isp = file->private_data;
++
++	return simple_read_from_buffer(buf, len, ppos,
++				       isp->trace->psys.wpt.conf_dump_buffer,
++				       isp->trace->psys.wpt.size_conf_dump);
++}
++
++static ssize_t wptraceconf_write(struct file *file, const char __user *buf,
++				  size_t len, loff_t *ppos)
++{
++	int i;
++	struct ipu6_device *isp = file->private_data;
++	ssize_t bytes = 0;
++	char *wpt_info_buffer = NULL;
++	size_t buffer_size = 0;
++	u32 wp_node_number = 0;
++	struct config_value *wpt_buffer = NULL;
++	struct ipu_subsystem_wptrace_config *wpt = &isp->trace->psys.wpt;
++
++	if ((*ppos < 0) || (len > WPT_TRACE_CONF_DATA_MAX_LEN) ||
++	    (len < sizeof(wp_node_number))) {
++		dev_info(&isp->pdev->dev,
++			 "length is error, len:%ld, loff:%lld\n",
++			 len, *ppos);
++		return -EINVAL;
++	}
++
++	wpt_info_buffer = vzalloc(len);
++	if (!wpt_info_buffer)
++		return -ENOMEM;
++
++	bytes = copy_from_user(wpt_info_buffer, buf, len);
++	if (bytes != 0) {
++		vfree(wpt_info_buffer);
++		return -EFAULT;
++	}
++
++	memcpy(&wp_node_number, wpt_info_buffer, sizeof(u32));
++	buffer_size = wp_node_number * sizeof(struct config_value);
++	if ((buffer_size + sizeof(wp_node_number)) != len) {
++		dev_info(&isp->pdev->dev,
++			 "File size is not right, len:%ld, buffer_size:%zu\n",
++			 len, buffer_size);
++		vfree(wpt_info_buffer);
++		return -EFAULT;
++	}
++
++	mutex_lock(&isp->trace->lock);
++	wpt_buffer = (struct config_value *)(wpt_info_buffer + sizeof(u32));
++	for (i = 0; i < wp_node_number; i++) {
++		if (wpt->fill_level < MAX_TRACE_REGISTERS) {
++			wpt->config[wpt->fill_level].reg = wpt_buffer[i].reg;
++			wpt->config[wpt->fill_level].value =
++				wpt_buffer[i].value;
++			wpt->fill_level++;
++		} else {
++			dev_info(&isp->pdev->dev,
++				 "Address 0x%08x ignored as invalid register\n",
++				 wpt_buffer[i].reg);
++			break;
++		}
++	}
++	mutex_unlock(&isp->trace->lock);
++	vfree(wpt_info_buffer);
++
++	return len;
++}
++
++static int wptraceconf_release(struct inode *inode, struct file *file)
++{
++	struct ipu6_device *isp = file->private_data;
++
++	mutex_lock(&isp->trace->lock);
++	isp->trace->open = 0;
++	vfree(isp->trace->psys.wpt.conf_dump_buffer);
++	isp->trace->psys.wpt.conf_dump_buffer = NULL;
++	mutex_unlock(&isp->trace->lock);
++
++	return 0;
++}
++
++static const struct file_operations ipu_wptraceconf_fops = {
++	.owner = THIS_MODULE,
++	.open = wptraceconf_open,
++	.release = wptraceconf_release,
++	.read = wptraceconf_read,
++	.write = wptraceconf_write,
++	.llseek = noop_llseek,
++};
++
++static int gettrace_open(struct inode *inode, struct file *file)
++{
++	struct ipu_subsystem_trace_config *sys = inode->i_private;
++
++	if (!sys)
++		return -EACCES;
++
++	if (!sys->memory.memory_buffer)
++		return -EACCES;
++
++	dma_sync_single_for_cpu(sys->dev,
++				sys->memory.dma_handle,
++				MEMORY_RING_BUFFER_SIZE +
++				MEMORY_RING_BUFFER_GUARD, DMA_FROM_DEVICE);
++
++	file->private_data = sys;
++	return 0;
++};
++
++static ssize_t gettrace_read(struct file *file, char __user *buf,
++			      size_t len, loff_t *ppos)
++{
++	struct ipu_subsystem_trace_config *sys = file->private_data;
++
++	return simple_read_from_buffer(buf, len, ppos,
++				       sys->memory.memory_buffer,
++				       MEMORY_RING_BUFFER_SIZE +
++				       MEMORY_RING_BUFFER_OVERREAD);
++}
++
++static ssize_t gettrace_write(struct file *file, const char __user *buf,
++			       size_t len, loff_t *ppos)
++{
++	struct ipu_subsystem_trace_config *sys = file->private_data;
++	static const char str[] = "clear";
++	char buffer[sizeof(str)] = { 0 };
++	ssize_t ret;
++
++	ret = simple_write_to_buffer(buffer, sizeof(buffer), ppos, buf, len);
++	if (ret < 0)
++		return ret;
++
++	if (ret < sizeof(str) - 1)
++		return -EINVAL;
++
++	if (!strncmp(str, buffer, sizeof(str) - 1)) {
++		clear_trace_buffer(sys);
++		return len;
++	}
++
++	return -EINVAL;
++}
++
++static int gettrace_release(struct inode *inode, struct file *file)
++{
++	return 0;
++}
++
++static const struct file_operations ipu_gettrace_fops = {
++	.owner = THIS_MODULE,
++	.open = gettrace_open,
++	.release = gettrace_release,
++	.read = gettrace_read,
++	.write = gettrace_write,
++	.llseek = noop_llseek,
++};
++
++int ipu_trace_init(struct ipu6_device *isp, void __iomem *base,
++		   struct device *dev, struct ipu_trace_block *blocks)
++{
++	struct ipu6_bus_device *adev = to_ipu6_bus_device(dev);
++	struct ipu_trace *trace = isp->trace;
++	struct ipu_subsystem_trace_config *sys;
++	int ret = 0;
++
++	if (!isp->trace)
++		return 0;
++
++	mutex_lock(&isp->trace->lock);
++
++	if (dev == &isp->isys->auxdev.dev) {
++		sys = &trace->isys;
++	} else if (dev == &isp->psys->auxdev.dev) {
++		sys = &trace->psys;
++	} else {
++		ret = -EINVAL;
++		goto leave;
++	}
++
++	adev->trace_cfg = sys;
++	sys->dev = dev;
++	sys->offset = base - isp->base;	/* sub system offset */
++	sys->base = base;
++	sys->blocks = blocks;
++
++	sys->memory.memory_buffer =
++	    ipu6_dma_alloc(adev, MEMORY_RING_BUFFER_SIZE +
++			       MEMORY_RING_BUFFER_GUARD,
++			       &sys->memory.dma_handle,
++			       GFP_KERNEL, 0);
++
++	if (!sys->memory.memory_buffer)
++		dev_err(dev, "failed alloc memory for tracing.\n");
++
++leave:
++	mutex_unlock(&isp->trace->lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(ipu_trace_init);
++
++void ipu_trace_uninit(struct device *dev)
++{
++	struct ipu6_bus_device *adev = to_ipu6_bus_device(dev);
++	struct ipu6_device *isp = adev->isp;
++	struct ipu_trace *trace = isp->trace;
++	struct ipu_subsystem_trace_config *sys = adev->trace_cfg;
++
++	if (!trace || !sys)
++		return;
++
++	mutex_lock(&trace->lock);
++
++	if (sys->memory.memory_buffer)
++		ipu6_dma_free(
++			adev,
++			MEMORY_RING_BUFFER_SIZE + MEMORY_RING_BUFFER_GUARD,
++			sys->memory.memory_buffer, sys->memory.dma_handle, 0);
++
++	sys->dev = NULL;
++	sys->memory.memory_buffer = NULL;
++
++	mutex_unlock(&trace->lock);
++}
++EXPORT_SYMBOL_GPL(ipu_trace_uninit);
++
++int ipu_trace_debugfs_add(struct ipu6_device *isp, struct dentry *dir)
++{
++	struct dentry *files[4];
++	int i = 0;
++
++	if (!ipu_trace_enable)
++		return 0;
++
++	files[i] = debugfs_create_file("traceconf", 0644,
++				       dir, isp, &ipu_traceconf_fops);
++	if (!files[i])
++		return -ENOMEM;
++	i++;
++
++	files[i] = debugfs_create_file("wptraceconf", 0644,
++				       dir, isp, &ipu_wptraceconf_fops);
++	if (!files[i])
++		goto error;
++	i++;
++
++	files[i] = debugfs_create_file("getisystrace", 0444,
++				       dir,
++				       &isp->trace->isys, &ipu_gettrace_fops);
++
++	if (!files[i])
++		goto error;
++	i++;
++
++	files[i] = debugfs_create_file("getpsystrace", 0444,
++				       dir,
++				       &isp->trace->psys, &ipu_gettrace_fops);
++	if (!files[i])
++		goto error;
++
++	return 0;
++
++error:
++	for (; i > 0; i--)
++		debugfs_remove(files[i - 1]);
++	return -ENOMEM;
++}
++
++int ipu_trace_add(struct ipu6_device *isp)
++{
++	if (!ipu_trace_enable)
++		return 0;
++
++	isp->trace = devm_kzalloc(&isp->pdev->dev,
++				  sizeof(struct ipu_trace), GFP_KERNEL);
++	if (!isp->trace)
++		return -ENOMEM;
++
++	mutex_init(&isp->trace->lock);
++
++	dev_dbg(&isp->pdev->dev, "ipu trace enabled!");
++
++	return 0;
++}
++
++void ipu_trace_release(struct ipu6_device *isp)
++{
++	if (!isp->trace)
++		return;
++	mutex_destroy(&isp->trace->lock);
++}
++
++int ipu_trace_buffer_dma_handle(struct device *dev, dma_addr_t *dma_handle)
++{
++	struct ipu6_bus_device *adev = to_ipu6_bus_device(dev);
++	struct ipu_subsystem_trace_config *sys = adev->trace_cfg;
++
++	if (!ipu_trace_enable)
++		return -EACCES;
++
++	if (!sys || !sys->memory.memory_buffer)
++		return -EACCES;
++
++	*dma_handle = sys->memory.dma_handle;
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(ipu_trace_buffer_dma_handle);
++
++MODULE_AUTHOR("Samu Onkalo <samu.onkalo@intel.com>");
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("Intel ipu trace support");
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-trace.h b/drivers/media/pci/intel/ipu6/ipu6-trace.h
+new file mode 100644
+index 000000000000..f66d8898b1db
+--- /dev/null
++++ b/drivers/media/pci/intel/ipu6/ipu6-trace.h
+@@ -0,0 +1,147 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/* Copyright (C) 2014 - 2025 Intel Corporation */
++
++#ifndef IPU_TRACE_H
++#define IPU_TRACE_H
++#include <linux/debugfs.h>
++
++/* Trace unit register offsets */
++#define TRACE_REG_TUN_DDR_ENABLE        0x000
++#define TRACE_REG_TUN_NPK_ENABLE	0x004
++#define TRACE_REG_TUN_DDR_INFO_VAL	0x008
++#define TRACE_REG_TUN_NPK_ADDR		0x00C
++#define TRACE_REG_TUN_DRAM_BASE_ADDR	0x010
++#define TRACE_REG_TUN_DRAM_END_ADDR	0x014
++#define TRACE_REG_TUN_LOCAL_TIMER0	0x018
++#define TRACE_REG_TUN_LOCAL_TIMER1	0x01C
++#define TRACE_REG_TUN_WR_PTR		0x020
++#define TRACE_REG_TUN_RD_PTR		0x024
++
++/*
++ * Following registers are left out on purpose:
++ * TUN_LOCAL_TIMER0, TUN_LOCAL_TIMER1, TUN_DRAM_BASE_ADDR
++ * TUN_DRAM_END_ADDR, TUN_WR_PTR, TUN_RD_PTR
++ */
++
++/* Trace monitor register offsets */
++#define TRACE_REG_TM_TRACE_ADDR_A		0x0900
++#define TRACE_REG_TM_TRACE_ADDR_B		0x0904
++#define TRACE_REG_TM_TRACE_ADDR_C		0x0908
++#define TRACE_REG_TM_TRACE_ADDR_D		0x090c
++#define TRACE_REG_TM_TRACE_ENABLE_NPK		0x0910
++#define TRACE_REG_TM_TRACE_ENABLE_DDR		0x0914
++#define TRACE_REG_TM_TRACE_PER_PC		0x0918
++#define TRACE_REG_TM_TRACE_PER_BRANCH		0x091c
++#define TRACE_REG_TM_TRACE_HEADER		0x0920
++#define TRACE_REG_TM_TRACE_CFG			0x0924
++#define TRACE_REG_TM_TRACE_LOST_PACKETS		0x0928
++#define TRACE_REG_TM_TRACE_LP_CLEAR		0x092c
++#define TRACE_REG_TM_TRACE_LMRUN_MASK		0x0930
++#define TRACE_REG_TM_TRACE_LMRUN_PC_LOW		0x0934
++#define TRACE_REG_TM_TRACE_LMRUN_PC_HIGH	0x0938
++#define TRACE_REG_TM_TRACE_MMIO_SEL		0x093c
++#define TRACE_REG_TM_TRACE_MMIO_WP0_LOW		0x0940
++#define TRACE_REG_TM_TRACE_MMIO_WP1_LOW		0x0944
++#define TRACE_REG_TM_TRACE_MMIO_WP2_LOW		0x0948
++#define TRACE_REG_TM_TRACE_MMIO_WP3_LOW		0x094c
++#define TRACE_REG_TM_TRACE_MMIO_WP0_HIGH	0x0950
++#define TRACE_REG_TM_TRACE_MMIO_WP1_HIGH	0x0954
++#define TRACE_REG_TM_TRACE_MMIO_WP2_HIGH	0x0958
++#define TRACE_REG_TM_TRACE_MMIO_WP3_HIGH	0x095c
++#define TRACE_REG_TM_FWTRACE_FIRST		0x0A00
++#define TRACE_REG_TM_FWTRACE_MIDDLE		0x0A04
++#define TRACE_REG_TM_FWTRACE_LAST		0x0A08
++
++/*
++ * Following exists only in (I)SP address space:
++ * TM_FWTRACE_FIRST, TM_FWTRACE_MIDDLE, TM_FWTRACE_LAST
++ */
++
++#define TRACE_REG_GPC_RESET			0x000
++#define TRACE_REG_GPC_OVERALL_ENABLE		0x004
++#define TRACE_REG_GPC_TRACE_HEADER		0x008
++#define TRACE_REG_GPC_TRACE_ADDRESS		0x00C
++#define TRACE_REG_GPC_TRACE_NPK_EN		0x010
++#define TRACE_REG_GPC_TRACE_DDR_EN		0x014
++#define TRACE_REG_GPC_TRACE_LPKT_CLEAR		0x018
++#define TRACE_REG_GPC_TRACE_LPKT		0x01C
++
++#define TRACE_REG_GPC_ENABLE_ID0		0x020
++#define TRACE_REG_GPC_ENABLE_ID1		0x024
++#define TRACE_REG_GPC_ENABLE_ID2		0x028
++#define TRACE_REG_GPC_ENABLE_ID3		0x02c
++
++#define TRACE_REG_GPC_VALUE_ID0			0x030
++#define TRACE_REG_GPC_VALUE_ID1			0x034
++#define TRACE_REG_GPC_VALUE_ID2			0x038
++#define TRACE_REG_GPC_VALUE_ID3			0x03c
++
++#define TRACE_REG_GPC_CNT_INPUT_SELECT_ID0	0x040
++#define TRACE_REG_GPC_CNT_INPUT_SELECT_ID1	0x044
++#define TRACE_REG_GPC_CNT_INPUT_SELECT_ID2	0x048
++#define TRACE_REG_GPC_CNT_INPUT_SELECT_ID3	0x04c
++
++#define TRACE_REG_GPC_CNT_START_SELECT_ID0	0x050
++#define TRACE_REG_GPC_CNT_START_SELECT_ID1	0x054
++#define TRACE_REG_GPC_CNT_START_SELECT_ID2	0x058
++#define TRACE_REG_GPC_CNT_START_SELECT_ID3	0x05c
++
++#define TRACE_REG_GPC_CNT_STOP_SELECT_ID0	0x060
++#define TRACE_REG_GPC_CNT_STOP_SELECT_ID1	0x064
++#define TRACE_REG_GPC_CNT_STOP_SELECT_ID2	0x068
++#define TRACE_REG_GPC_CNT_STOP_SELECT_ID3	0x06c
++
++#define TRACE_REG_GPC_CNT_MSG_SELECT_ID0	0x070
++#define TRACE_REG_GPC_CNT_MSG_SELECT_ID1	0x074
++#define TRACE_REG_GPC_CNT_MSG_SELECT_ID2	0x078
++#define TRACE_REG_GPC_CNT_MSG_SELECT_ID3	0x07c
++
++#define TRACE_REG_GPC_CNT_MSG_PLOAD_SELECT_ID0	0x080
++#define TRACE_REG_GPC_CNT_MSG_PLOAD_SELECT_ID1	0x084
++#define TRACE_REG_GPC_CNT_MSG_PLOAD_SELECT_ID2	0x088
++#define TRACE_REG_GPC_CNT_MSG_PLOAD_SELECT_ID3	0x08c
++
++#define TRACE_REG_GPC_IRQ_TRIGGER_VALUE_ID0	0x090
++#define TRACE_REG_GPC_IRQ_TRIGGER_VALUE_ID1	0x094
++#define TRACE_REG_GPC_IRQ_TRIGGER_VALUE_ID2	0x098
++#define TRACE_REG_GPC_IRQ_TRIGGER_VALUE_ID3	0x09c
++
++#define TRACE_REG_GPC_IRQ_TIMER_SELECT_ID0	0x0a0
++#define TRACE_REG_GPC_IRQ_TIMER_SELECT_ID1	0x0a4
++#define TRACE_REG_GPC_IRQ_TIMER_SELECT_ID2	0x0a8
++#define TRACE_REG_GPC_IRQ_TIMER_SELECT_ID3	0x0ac
++
++#define TRACE_REG_GPC_IRQ_ENABLE_ID0		0x0b0
++#define TRACE_REG_GPC_IRQ_ENABLE_ID1		0x0b4
++#define TRACE_REG_GPC_IRQ_ENABLE_ID2		0x0b8
++#define TRACE_REG_GPC_IRQ_ENABLE_ID3		0x0bc
++
++struct ipu_trace;
++struct ipu_subsystem_trace_config;
++
++enum ipu_trace_block_type {
++	IPU_TRACE_BLOCK_TUN = 0,	/* Trace unit */
++	IPU_TRACE_BLOCK_TM,	/* Trace monitor */
++	IPU_TRACE_BLOCK_GPC,	/* General purpose control */
++	IPU_TRACE_CSI2,	/* CSI2 legacy receiver */
++	IPU_TRACE_CSI2_3PH,	/* CSI2 combo receiver */
++	IPU_TRACE_SIG2CIOS,
++	IPU_TRACE_TIMER_RST,	/* Trace reset control timer */
++	IPU_TRACE_BLOCK_END	/* End of list */
++};
++
++struct ipu_trace_block {
++	u32 offset;	/* Offset to block inside subsystem */
++	enum ipu_trace_block_type type;
++};
++
++int ipu_trace_add(struct ipu6_device *isp);
++int ipu_trace_debugfs_add(struct ipu6_device *isp, struct dentry *dir);
++void ipu_trace_release(struct ipu6_device *isp);
++int ipu_trace_init(struct ipu6_device *isp, void __iomem *base,
++		   struct device *dev, struct ipu_trace_block *blocks);
++void ipu_trace_restore(struct device *dev);
++void ipu_trace_uninit(struct device *dev);
++void ipu_trace_stop(struct device *dev);
++int ipu_trace_buffer_dma_handle(struct device *dev, dma_addr_t *dma_handle);
++#endif
+diff --git a/drivers/media/pci/intel/ipu6/ipu6.c b/drivers/media/pci/intel/ipu6/ipu6.c
+index 39a4bb2cdaa7..08b4101f6272 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6.c
++++ b/drivers/media/pci/intel/ipu6/ipu6.c
+@@ -32,6 +32,7 @@
+ #include "ipu6-platform-buttress-regs.h"
+ #include "ipu6-platform-isys-csi2-reg.h"
+ #include "ipu6-platform-regs.h"
++#include "ipu6-trace.h"
+
+ static unsigned int isys_freq_override;
+ module_param(isys_freq_override, uint, 0660);
+@@ -507,6 +508,37 @@ static int ipu6_pci_config_setup(struct pci_dev *dev, u8 hw_ver)
+ 	return 0;
+ }
+
++#ifdef CONFIG_DEBUG_FS
++static int ipu_init_debugfs(struct ipu6_device *isp)
++{
++	struct dentry *dir;
++
++	dir = debugfs_create_dir(IPU6_NAME, NULL);
++	if (!dir)
++		return -ENOMEM;
++
++	if (ipu_trace_debugfs_add(isp, dir))
++		goto err;
++
++	isp->ipu_dir = dir;
++
++	return 0;
++err:
++	debugfs_remove_recursive(dir);
++	return -ENOMEM;
++}
++
++static void ipu_remove_debugfs(struct ipu6_device *isp)
++{
++	/*
++	 * Since isys and psys debugfs dir will be created under ipu root dir,
++	 * mark its dentry to NULL to avoid duplicate removal.
++	 */
++	debugfs_remove_recursive(isp->ipu_dir);
++	isp->ipu_dir = NULL;
++}
++#endif /* CONFIG_DEBUG_FS */
++
+ static void ipu6_configure_vc_mechanism(struct ipu6_device *isp)
+ {
+ 	u32 val = readl(isp->base + BUTTRESS_REG_BTRS_CTRL);
+@@ -615,6 +647,10 @@ static int ipu6_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		goto buttress_exit;
+ 	}
+
++	ret = ipu_trace_add(isp);
++	if (ret)
++		dev_err(&isp->pdev->dev, "Trace support not available\n");
++
+ 	ret = ipu6_cpd_validate_cpd_file(isp, isp->cpd_fw->data,
+ 					 isp->cpd_fw->size);
+ 	if (ret) {
+@@ -694,6 +730,13 @@ static int ipu6_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 	ipu6_mmu_hw_cleanup(isp->psys->mmu);
+ 	pm_runtime_put(&isp->psys->auxdev.dev);
+
++#ifdef CONFIG_DEBUG_FS
++	ret = ipu_init_debugfs(isp);
++	if (ret) {
++		dev_err(&isp->pdev->dev, "Failed to initialize debugfs");
++	}
++#endif
++
+ 	/* Configure the arbitration mechanisms for VC requests */
+ 	ipu6_configure_vc_mechanism(isp);
+
+@@ -735,6 +778,11 @@ static void ipu6_pci_remove(struct pci_dev *pdev)
+ 	struct ipu6_mmu *isys_mmu = isp->isys->mmu;
+ 	struct ipu6_mmu *psys_mmu = isp->psys->mmu;
+
++#ifdef CONFIG_DEBUG_FS
++	ipu_remove_debugfs(isp);
++#endif
++	ipu_trace_release(isp);
++
+ 	devm_free_irq(&pdev->dev, pdev->irq, isp);
+ 	ipu6_cpd_free_pkg_dir(isp->psys);
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6.h b/drivers/media/pci/intel/ipu6/ipu6.h
+index 92e3c3414c91..d91a78ef28b5 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6.h
++++ b/drivers/media/pci/intel/ipu6/ipu6.h
+@@ -82,10 +82,15 @@ struct ipu6_device {
+ 	u32 cpd_metadata_cmpnt_size;
+
+ 	void __iomem *base;
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *ipu_dir;
++#endif
+ 	bool need_ipc_reset;
+ 	bool secure_mode;
+ 	u8 hw_ver;
+ 	bool bus_ready_to_probe;
++
++	struct ipu_trace *trace;
+ };
+
+ #define IPU6_ISYS_NAME "isys"
+--
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0033-Support-IPU6-PSYS-FW-trace-dump-for-upstream-driver.patch
+++ b/kernel_patches/patch_6.12_mainline/0033-Support-IPU6-PSYS-FW-trace-dump-for-upstream-driver.patch
@@ -1,0 +1,132 @@
+From da41fbb54f5d8141ef93e2eaefb286c59fdca7db Mon Sep 17 00:00:00 2001
+From: hepengpx <pengpengx.he@intel.com>
+Date: Fri, 25 Apr 2025 09:44:01 +0800
+Subject: [PATCH] Support IPU6 PSYS FW trace dump for upstream driver
+
+Signed-off-by: hepengpx <pengpengx.he@intel.com>
+---
+ drivers/media/pci/intel/ipu6/ipu6-trace.c    |  6 +++
+ drivers/media/pci/intel/ipu6/ipu6-trace.h    |  1 +
+ drivers/media/pci/intel/ipu6/psys/ipu-psys.c | 44 +++++++++++++++++++-
+ 3 files changed, 50 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-trace.c b/drivers/media/pci/intel/ipu6/ipu6-trace.c
+index adcee205ad95..077f140921cb 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-trace.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-trace.c
+@@ -891,6 +891,12 @@ int ipu_trace_buffer_dma_handle(struct device *dev, dma_addr_t *dma_handle)
+ }
+ EXPORT_SYMBOL_GPL(ipu_trace_buffer_dma_handle);
+
++bool is_ipu_trace_enable(void)
++{
++	return ipu_trace_enable;
++}
++EXPORT_SYMBOL_GPL(is_ipu_trace_enable);
++
+ MODULE_AUTHOR("Samu Onkalo <samu.onkalo@intel.com>");
+ MODULE_LICENSE("GPL");
+ MODULE_DESCRIPTION("Intel ipu trace support");
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-trace.h b/drivers/media/pci/intel/ipu6/ipu6-trace.h
+index f66d8898b1db..fe89d1b203b6 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-trace.h
++++ b/drivers/media/pci/intel/ipu6/ipu6-trace.h
+@@ -144,4 +144,5 @@ void ipu_trace_restore(struct device *dev);
+ void ipu_trace_uninit(struct device *dev);
+ void ipu_trace_stop(struct device *dev);
+ int ipu_trace_buffer_dma_handle(struct device *dev, dma_addr_t *dma_handle);
++bool is_ipu_trace_enable(void);
+ #endif
+diff --git a/drivers/media/pci/intel/ipu6/psys/ipu-psys.c b/drivers/media/pci/intel/ipu6/psys/ipu-psys.c
+index 9f367496cbd0..e8638a918215 100644
+--- a/drivers/media/pci/intel/ipu6/psys/ipu-psys.c
++++ b/drivers/media/pci/intel/ipu6/psys/ipu-psys.c
+@@ -31,6 +31,7 @@
+ #include "ipu-psys.h"
+ #include "ipu6-platform-regs.h"
+ #include "ipu6-fw-com.h"
++#include "ipu6-trace.h"
+
+ static bool async_fw_init;
+ module_param(async_fw_init, bool, 0664);
+@@ -1201,6 +1202,8 @@ static int ipu_psys_sched_cmd(void *ptr)
+ 	return 0;
+ }
+
++#include "../ipu6-trace.h"
++
+ static void start_sp(struct ipu6_bus_device *adev)
+ {
+ 	struct ipu_psys *psys = ipu6_bus_get_drvdata(adev);
+@@ -1211,7 +1214,7 @@ static void start_sp(struct ipu6_bus_device *adev)
+ 	val |= IPU6_PSYS_SPC_STATUS_START |
+ 	    IPU6_PSYS_SPC_STATUS_RUN |
+ 	    IPU6_PSYS_SPC_STATUS_CTRL_ICACHE_INVALIDATE;
+-	val |= psys->icache_prefetch_sp ?
++	val |= (psys->icache_prefetch_sp || is_ipu_trace_enable()) ?
+ 	    IPU6_PSYS_SPC_STATUS_ICACHE_PREFETCH : 0;
+ 	writel(val, spc_regs_base + IPU6_PSYS_REG_SPC_STATUS_CTRL);
+ }
+@@ -1304,6 +1307,40 @@ static void run_fw_init_work(struct work_struct *work)
+ 	}
+ }
+
++struct ipu_trace_block psys_trace_blocks[] = {
++	{
++		.offset = IPU_TRACE_REG_PS_TRACE_UNIT_BASE,
++		.type = IPU_TRACE_BLOCK_TUN,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_SPC_EVQ_BASE,
++		.type = IPU_TRACE_BLOCK_TM,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_SPP0_EVQ_BASE,
++		.type = IPU_TRACE_BLOCK_TM,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_SPC_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_SPP0_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_MMU_GPC_BASE,
++		.type = IPU_TRACE_BLOCK_GPC,
++	},
++	{
++		.offset = IPU_TRACE_REG_PS_GPREG_TRACE_TIMER_RST_N,
++		.type = IPU_TRACE_TIMER_RST,
++	},
++	{
++		.type = IPU_TRACE_BLOCK_END,
++	}
++};
++
+ static int ipu6_psys_probe(struct auxiliary_device *auxdev,
+ 			   const struct auxiliary_device_id *auxdev_id)
+ {
+@@ -1442,6 +1479,9 @@ static int ipu6_psys_probe(struct auxiliary_device *auxdev,
+ 	strscpy(psys->caps.dev_model, IPU6_MEDIA_DEV_MODEL_NAME,
+ 		sizeof(psys->caps.dev_model));
+
++	ipu_trace_init(adev->isp, psys->pdata->base, &auxdev->dev,
++		psys_trace_blocks);
++
+ 	mutex_unlock(&ipu_psys_mutex);
+
+ 	dev_info(dev, "psys probe minor: %d\n", minor);
+@@ -1503,6 +1543,8 @@ static void ipu6_psys_remove(struct auxiliary_device *auxdev)
+
+ 	clear_bit(MINOR(psys->cdev.dev), ipu_psys_devices);
+
++	ipu_trace_uninit(&auxdev->dev);
++
+ 	mutex_unlock(&ipu_psys_mutex);
+
+ 	mutex_destroy(&psys->mutex);
+--
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0034-media-pci-The-order-of-return-buffers-should-be-FIFO.patch
+++ b/kernel_patches/patch_6.12_mainline/0034-media-pci-The-order-of-return-buffers-should-be-FIFO.patch
@@ -1,0 +1,97 @@
+From d10429626178490de5733a51fa041b3747921ade Mon Sep 17 00:00:00 2001
+From: zouxiaoh <xiaohong.zou@intel.com>
+Date: Fri, 16 May 2025 14:40:46 +0800
+Subject: [PATCH] media: pci: The order of return buffers should be FIFO.
+
+Change Description:
+return_buffers : use "list_first_entry", will get these logs in hal:
+“CamHAL[ERR] DeviceBase: dequeueBuffer, CamBuf index isn't same with
+index used by kernel
+CamHAL[ERR] CaptureUnit: Device:Generic grab frame failed:-22”
+
+The index order is changed from sequential to reverse after return_buffers.
+The reason why the normal start&stop does not expose the problem is that
+every Hal start will start the buffer index from 0 instead of continuing
+to use the buffer index returned last stop.
+
+So need return_buffers from the list of tail,
+and need use the "list_last_entry".
+
+Signed-off-by: linya14x <linx.yang@intel.com>
+Signed-off-by: zouxiaoh <xiaohong.zou@intel.com>
+---
+ .../media/pci/intel/ipu6/ipu6-isys-queue.c    | 31 ++++++++++---------
+ 1 file changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c b/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
+index b931c4374694..14868b1ab441 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-isys-queue.c
+@@ -519,39 +519,40 @@ static void return_buffers(struct ipu6_isys_queue *aq,
+ 	unsigned long flags;
+
+ 	spin_lock_irqsave(&aq->lock, flags);
+-	while (!list_empty(&aq->incoming)) {
++
++	/*
++	 * Something went wrong (FW crash / HW hang / not all buffers
++	 * returned from isys) if there are still buffers queued in active
++	 * queue. We have to clean up places a bit.
++	 */
++	while (!list_empty(&aq->active)) {
+ 		struct vb2_buffer *vb;
+
+-		ib = list_first_entry(&aq->incoming, struct ipu6_isys_buffer,
+-				      head);
++		ib = list_last_entry(&aq->active, struct ipu6_isys_buffer,
++				     head);
+ 		vb = ipu6_isys_buffer_to_vb2_buffer(ib);
++
+ 		list_del(&ib->head);
+ 		spin_unlock_irqrestore(&aq->lock, flags);
+
+ 		vb2_buffer_done(vb, state);
+
+ 		spin_lock_irqsave(&aq->lock, flags);
++		need_reset = true;
+ 	}
+
+-	/*
+-	 * Something went wrong (FW crash / HW hang / not all buffers
+-	 * returned from isys) if there are still buffers queued in active
+-	 * queue. We have to clean up places a bit.
+-	 */
+-	while (!list_empty(&aq->active)) {
++	while (!list_empty(&aq->incoming)) {
+ 		struct vb2_buffer *vb;
+
+-		ib = list_first_entry(&aq->active, struct ipu6_isys_buffer,
+-				      head);
++		ib = list_last_entry(&aq->incoming, struct ipu6_isys_buffer,
++				     head);
+ 		vb = ipu6_isys_buffer_to_vb2_buffer(ib);
+-
+ 		list_del(&ib->head);
+ 		spin_unlock_irqrestore(&aq->lock, flags);
+
+ 		vb2_buffer_done(vb, state);
+
+ 		spin_lock_irqsave(&aq->lock, flags);
+-		need_reset = true;
+ 	}
+
+ 	spin_unlock_irqrestore(&aq->lock, flags);
+@@ -699,8 +700,8 @@ static int reset_start_streaming(struct ipu6_isys_video *av)
+
+ 	spin_lock_irqsave(&aq->lock, flags);
+ 	while (!list_empty(&aq->active)) {
+-		struct ipu6_isys_buffer *ib = list_first_entry(&aq->active,
+-			struct ipu6_isys_buffer, head);
++		struct ipu6_isys_buffer *ib = list_last_entry(&aq->active,
++							      struct ipu6_isys_buffer, head);
+
+ 		list_del(&ib->head);
+ 		list_add_tail(&ib->head, &aq->incoming);
+--
+2.43.0
+

--- a/kernel_patches/patch_6.12_mainline/0036-media-i2c-fix-power-on-issue-for-on-board-LT6911UXE.patch
+++ b/kernel_patches/patch_6.12_mainline/0036-media-i2c-fix-power-on-issue-for-on-board-LT6911UXE.patch
@@ -1,0 +1,28 @@
+From 7c7be2c362335df7182aa15e992f2d764b27f9ca Mon Sep 17 00:00:00 2001
+From: hepengpx <pengpengx.he@intel.com>
+Date: Mon, 12 May 2025 18:19:49 +0800
+Subject: [PATCH] media: i2c: fix power-on issue for on-board LT6911UXE
+
+For on board LT6911UXE, RESET GPIO should be output type.
+
+Signed-off-by: hepengpx <pengpengx.he@intel.com>
+---
+ drivers/media/i2c/lt6911uxe.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/lt6911uxe.c b/drivers/media/i2c/lt6911uxe.c
+index c5b40bb58a37..4e2109db0145 100644
+--- a/drivers/media/i2c/lt6911uxe.c
++++ b/drivers/media/i2c/lt6911uxe.c
+@@ -600,7 +600,7 @@ static int lt6911uxe_probe(struct i2c_client *client)
+
+ 	v4l2_i2c_subdev_init(&lt6911uxe->sd, client, &lt6911uxe_subdev_ops);
+
+-	lt6911uxe->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_IN);
++	lt6911uxe->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
+ 	if (IS_ERR(lt6911uxe->reset_gpio))
+ 		return dev_err_probe(dev, PTR_ERR(lt6911uxe->reset_gpio),
+ 				     "failed to get reset gpio\n");
+--
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/README
+++ b/kernel_patches/patch_6.12_mainline/README
@@ -20,9 +20,16 @@ build kernel driver with community kernel version 6.11 but not iot kernel
        git am 0014-media-i2c-update-lt6911uxc-driver-to-fix-COV-issue.patch
        git am 0015-lt6911-2-pads-linked-to-ipu-2-ports-for-split-mode.patch
        git am 0016-media-i2c-add-dv_timings-api-in-lt6911uxe_for_ecg_kernel.patch
+       git am 0017-media-intel-ipu6-use-vc1-dma-for-MTL-and-ARL.patch
        git am 0018-some-changes-in-lt6911uxe.patch
        git am 0019-media-i2c-update-format-in-irq-for-lt6911uxe.patch
        git am 0020-media-i2c-remove-unused-func-in-lt6911uxe.patch
+
+       git am 0031-media-ipu-Dma-sync-at-buffer_prepare-callback-as-DMA.patch
+       git am 0032-Support-IPU6-ISYS-FW-trace-dump-for-upstream-driver.patch
+       git am 0033-Support-IPU6-PSYS-FW-trace-dump-for-upstream-driver.patch
+       git am 0034-media-pci-The-order-of-return-buffers-should-be-FIFO.patch
+       git am 0036-media-i2c-fix-power-on-issue-for-on-board-LT6911UXE.patch
 
     b. for PSYS driver (the patch be integrated in NEX kernel 6.12):
        git am 0001-media-pci-intel-psys-driver.patch


### PR DESCRIPTION
        0017-media-intel-ipu6-use-vc1-dma-for-MTL-and-ARL.patch
        0031-media-ipu-Dma-sync-at-buffer_prepare-callback-as-DMA.patch
        0032-Support-IPU6-ISYS-FW-trace-dump-for-upstream-driver.patch
        0033-Support-IPU6-PSYS-FW-trace-dump-for-upstream-driver.patch
        0034-media-pci-The-order-of-return-buffers-should-be-FIFO.patch
        0036-media-i2c-fix-power-on-issue-for-on-board-LT6911UXE.patch