### PR TITLE
ARL MR2, TWL MR1, ASL MR4 releases on kernel 6.12 Ubuntu 24.04 (iot)

### DIFF
--- a/kernel_patches/patch_6.12_mainline/0035-media-i2c-fix-power-on-issue-for-on-board-LT6911UXC.patch
+++ b/kernel_patches/patch_6.12_mainline/0035-media-i2c-fix-power-on-issue-for-on-board-LT6911UXC.patch
@@ -1,0 +1,26 @@
+From 0fd640b00c0cbaf0511ca6e284d7d6d08a3a6a81 Mon Sep 17 00:00:00 2001
+From: hepengpx <pengpengx.he@intel.com>
+Date: Wed, 21 May 2025 10:26:12 +0800
+Subject: [PATCH] media: i2c: fix power-on issue for on board LT6911UXC
+
+Signed-off-by: hepengpx <pengpengx.he@intel.com>
+---
+ drivers/media/i2c/lt6911uxc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/lt6911uxc.c b/drivers/media/i2c/lt6911uxc.c
+index eb8ff5747100..c84de5a3c139 100644
+--- a/drivers/media/i2c/lt6911uxc.c
++++ b/drivers/media/i2c/lt6911uxc.c
+@@ -553,7 +553,7 @@ static int lt6911uxc_identify_module(struct lt6911uxc *lt6911uxc,
+
+ static int lt6911uxc_parse_gpio(struct lt6911uxc *lt6911uxc, struct device *dev)
+ {
+-	lt6911uxc->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_IN);
++	lt6911uxc->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
+ 	if (IS_ERR(lt6911uxc->reset_gpio)) {
+ 		lt6911uxc->auxiliary_port = true;
+ 		return dev_err_probe(dev, PTR_ERR(lt6911uxc->reset_gpio),
+--
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/README
+++ b/kernel_patches/patch_6.12_mainline/README
@@ -29,6 +29,7 @@ build kernel driver with community kernel version 6.11 but not iot kernel
        git am 0032-Support-IPU6-ISYS-FW-trace-dump-for-upstream-driver.patch
        git am 0033-Support-IPU6-PSYS-FW-trace-dump-for-upstream-driver.patch
        git am 0034-media-pci-The-order-of-return-buffers-should-be-FIFO.patch
+       git am 0035-media-i2c-fix-power-on-issue-for-on-board-LT6911UXC.patch
        git am 0036-media-i2c-fix-power-on-issue-for-on-board-LT6911UXE.patch
 
     b. for PSYS driver (the patch be integrated in NEX kernel 6.12):


### PR DESCRIPTION
Add patch for on board LT6911UXC
0035-media-i2c-fix-power-on-issue-for-on-board-LT6911UXC.patch