### PR TITLE
fix the stream_mutex not init issue

### DIFF
--- a/drivers/media/pci/intel/ipu-isys-csi2.c
+++ b/drivers/media/pci/intel/ipu-isys-csi2.c
@@ -565,6 +565,7 @@ int ipu_isys_csi2_init(struct ipu_isys_csi2 *csi2,
 	csi2->asd.ctrl_init = csi_ctrl_init;
 	csi2->asd.isys = isys;
 	init_completion(&csi2->eof_completion);
+	mutex_init(&csi2->stream_mutex);
 	mutex_lock(&csi2->stream_mutex);
 	csi2->stream_count = 0;
 	mutex_unlock(&csi2->stream_mutex);


### PR DESCRIPTION
DEBUG_LOCKS_WARN_ON(lock->magic != lock)
RIP: 0010:__mutex_lock+0x875/0xbc0
Call Trace:
 <TASK>
 ? __warn+0x92/0x140
 ? __mutex_lock+0x875/0xbc0
 ? report_bug+0x14f/0x180
 ? handle_bug+0x53/0xc0
 ? exc_invalid_op+0x17/0x40
 ? asm_exc_invalid_op+0x1a/0x40
 ? ipu_isys_csi2_init+0x16c/0x580 [intel_ipu6_isys]
 ? ipu_isys_csi2_init+0x16c/0x580 [intel_ipu6_isys]
 ipu_isys_csi2_init+0x16c/0x580 [intel_ipu6_isys]
 ? __pfx_ipu_isys_csi2_init+0x40/0x40 [intel_ipu6_isys]
 isys_probe+0xada/0x1500 [intel_ipu6_isys]
 ipu_bus_probe+0xaa/0x1c0 [intel_ipu6]
 really_probe+0x276/0x5c0
 __driver_probe_device+0xc5/0x200
 driver_probe_device+0x45/0x100
 __driver_attach+0x135/0x280
 bus_for_each_dev+0xcf/0x140
 bus_add_driver+0x199/0x340
 driver_register+0x9b/0x1c0
 do_one_initcall+0xc1/0x300
 do_init_module+0x135/0x380
 load_module+0x2f66/0x3080