### PR TITLE
Add ISX031 mipi direct support for kernel v6.12.34

### DIFF
--- a/kernel_patches/patch_6.12_mainline/0059-media-isx031-Add-support-on-ISX031-MIPI-CSI.patch
+++ b/kernel_patches/patch_6.12_mainline/0059-media-isx031-Add-support-on-ISX031-MIPI-CSI.patch
@@ -1,0 +1,345 @@
+From c0bc32d888fb1c7d291b7b20f07f5d37cd18edcd Mon Sep 17 00:00:00 2001
+From: "Goh, Wei Khang1" <wei.khang1.goh@intel.com>
+Date: Thu, 16 Oct 2025 10:23:20 +0800
+Subject: [PATCH 1/3] media: isx031: Add support on ISX031 MIPI CSI
+
+* isx031: Add support on ISX031 MIPI CSI (D3)
+
+- Verified sensor driver compatibility with RPL & ARL kernel 6.12
+- Added ISX031 sensor driver implementation
+- Added reference XML configuration for ISX031 sensor
+- Added reference BIOS configuration for Camera Option & Control Logic
+- Added user-space command for sensor testing
+
+* isx031: Refine is_direct flag for sensor type checking
+
+- Simplified sensor type selection (MIPI/GMSL) using is_direct flag
+
+* isx031: Remove redundant isx031_reset()
+
+- Removed isx031_reset() as sensor reset action completed by devm_gpiod_get_optional().
+
+* isx031: Add sensor power control for isx031_suspend() & isx031_resume()
+
+- Added sensor power off for isx031_suspend()
+- Added sensor power on for isx031_resume()
+- Fixed compilation warning
+
+Signed-off-by: Lui, Jonathan Ming Jun <jonathan.ming.jun.lui@intel.com>
+Signed-off-by: Goh, Wei Khang1 <wei.khang1.goh@intel.com>
+---
+ drivers/media/i2c/isx031.c           | 146 +++++++++++++++++++++------
+ drivers/media/i2c/max9x/serdes.c     |   2 +-
+ drivers/media/pci/intel/ipu-bridge.c |   2 +
+ 3 files changed, 119 insertions(+), 31 deletions(-)
+
+diff --git a/drivers/media/i2c/isx031.c b/drivers/media/i2c/isx031.c
+index acaf41a82fbe..8a6f60ccdacb 100644
+--- a/drivers/media/i2c/isx031.c
++++ b/drivers/media/i2c/isx031.c
+@@ -34,6 +34,10 @@
+ #define ISX031_REG_MODE_SET_F_LOCK	0xBEF0
+ #define ISX031_MODE_UNLOCK		0x53
+ 
++struct isx031_info {
++	bool is_direct;
++};
++
+ struct isx031_reg {
+ 	enum {
+ 		ISX031_REG_LEN_DELAY = 0,
+@@ -79,7 +83,7 @@ struct isx031 {
+ 	/* Previous mode */
+ 	const struct isx031_mode *pre_mode;
+ 
+-	/* To serialize asynchronus callbacks */
++	/* To serialize asynchronous callbacks */
+ 	struct mutex mutex;
+ 
+ 	/* i2c client */
+@@ -90,6 +94,15 @@ struct isx031 {
+ 
+ 	/* Streaming on/off */
+ 	bool streaming;
++
++	struct v4l2_ctrl_handler ctrls;
++
++	/* MIPI direct connection */
++	bool is_direct;
++};
++
++static const s64 isx031_link_frequencies[] = {
++	300000000ULL
+ };
+ 
+ static const struct isx031_reg isx031_init_reg[] = {
+@@ -101,7 +114,7 @@ static const struct isx031_reg isx031_init_reg[] = {
+ static const struct isx031_reg isx031_framesync_reg[] = {
+ 	/* External sync */
+ 	{ISX031_REG_LEN_08BIT, 0xBF14, 0x01}, /* SG_MODE_APL */
+-	{ISX031_REG_LEN_08BIT, 0x8AFF, 0x0c}, /*  Hi-Z (input setting or output disabled) */
++	{ISX031_REG_LEN_08BIT, 0x8AFF, 0x0c}, /* Hi-Z (input setting or output disabled) */
+ 	{ISX031_REG_LEN_08BIT, 0x0153, 0x00},
+ 	{ISX031_REG_LEN_08BIT, 0x8AF0, 0x01}, /* external pulse-based sync */
+ 	{ISX031_REG_LEN_08BIT, 0x0144, 0x00},
+@@ -224,21 +237,6 @@ static const struct isx031_mode supported_modes[] = {
+ 	},
+ };
+ 
+-static int isx031_reset(struct gpio_desc *reset_gpio)
+-{
+-	if (!IS_ERR_OR_NULL(reset_gpio)) {
+-		gpiod_set_value_cansleep(reset_gpio, 0);
+-		usleep_range(500, 1000);
+-		gpiod_set_value_cansleep(reset_gpio, 1);
+-		/*Needs to sleep for quite a while before register writes*/
+-		usleep_range(200 * 1000, 200 * 1000 + 500);
+-
+-		return 0;
+-	}
+-
+-	return -EINVAL;
+-}
+-
+ static int isx031_read_reg(struct isx031 *isx031, u16 reg, u16 len, u32 *val)
+ {
+ 	struct i2c_client *client = isx031->client;
+@@ -351,7 +349,7 @@ static int isx031_mode_transit(struct isx031 *isx031, int state)
+ 		return ret;
+ 	}
+ 
+-	/*streaming transit to standby need 1 frame+5ms*/
++	/* streaming transit to standby need 1 frame+5ms */
+ 	retry = 50;
+ 	while (retry--) {
+ 		ret = isx031_read_reg(isx031, ISX031_REG_SENSOR_STATE,
+@@ -384,7 +382,7 @@ static int isx031_identify_module(struct isx031 *isx031)
+ 
+ 	dev_dbg(&client->dev, "sensor in mode 0x%x", val);
+ 
+-	/* if sensor alreay in ISX031_STATE_STARTUP, can access i2c write directly*/
++	/* if sensor alreay in ISX031_STATE_STARTUP, can access i2c write directly */
+ 	if (val == ISX031_STATE_STREAMING) {
+ 		if (isx031_mode_transit(isx031, ISX031_STATE_STARTUP))
+ 			return ret;
+@@ -431,6 +429,14 @@ static int isx031_start_streaming(struct isx031 *isx031)
+ 		dev_dbg(&client->dev, "same mode, skip write reg list");
+ 	}
+ 
++	if (isx031->is_direct) {
++		ret = __v4l2_ctrl_handler_setup(&isx031->ctrls);
++		if (ret) {
++			dev_err(&client->dev, "failed to setup ctrls");
++			return ret;
++		}
++	}
++
+ 	ret = isx031_mode_transit(isx031, ISX031_STATE_STREAMING);
+ 	if (ret) {
+ 		dev_err(&client->dev, "failed to start streaming");
+@@ -509,6 +515,9 @@ static int __maybe_unused isx031_suspend(struct device *dev)
+ 
+ 	mutex_unlock(&isx031->mutex);
+ 
++	/* Active low gpio reset, set 1 to power off sensor */
++	gpiod_set_value_cansleep(isx031->reset_gpio, 1);
++
+ 	return 0;
+ }
+ 
+@@ -519,9 +528,23 @@ static int __maybe_unused isx031_resume(struct device *dev)
+ 	struct isx031 *isx031 = to_isx031(sd);
+ 	const struct isx031_reg_list *reg_list;
+ 	int ret;
++	int count = 0;
+ 
+-	if (isx031->reset_gpio != NULL)
+-		isx031_reset(isx031->reset_gpio);
++	/* Active low gpio reset, set 0 to power on sensor,
++	 * sensor must on back before start resume
++	 */
++	if (isx031->reset_gpio != NULL) {
++		do {
++			gpiod_set_value_cansleep(isx031->reset_gpio, 0);
++			ret = gpiod_get_value_cansleep(isx031->reset_gpio);
++			usleep_range(200 * 1000, 200 * 1000 + 500);
++
++			if (++count >= 5) {
++				dev_err(&client->dev, "%s: failed to power on reset gpio, reset gpio is %d", __func__, ret);
++				break;
++			}
++		} while (ret != 0);
++	}
+ 
+ 	ret = isx031_identify_module(isx031);
+ 	if (ret == 0) {
+@@ -755,10 +778,40 @@ static void isx031_remove(struct i2c_client *client)
+ #endif
+ }
+ 
++static int isx031_set_ctrl(struct v4l2_ctrl *ctrl)
++{
++	return 0;
++}
++
++static const struct v4l2_ctrl_ops isx031_ctrl_ops = {
++	.s_ctrl = isx031_set_ctrl,
++};
++
++static int isx031_ctrls_init(struct isx031 *sensor)
++{
++	int ret = 0;
++	struct v4l2_ctrl *ctrl;
++
++	v4l2_ctrl_handler_init(&sensor->ctrls, 10);
++
++	/* There's a need to set the link frequency because IPU6 dictates it. */
++	ctrl = v4l2_ctrl_new_int_menu(&sensor->ctrls, &isx031_ctrl_ops,
++				      V4L2_CID_LINK_FREQ,
++				      ARRAY_SIZE(isx031_link_frequencies) - 1, 0,
++				      isx031_link_frequencies);
++
++	if (ctrl)
++		ctrl->flags |= V4L2_CTRL_FLAG_READ_ONLY;
++
++	sensor->sd.ctrl_handler = &sensor->ctrls;
++	return ret;
++}
++
+ static int isx031_probe(struct i2c_client *client)
+ {
+ 	struct v4l2_subdev *sd;
+ 	struct isx031 *isx031;
++	const struct isx031_info *info;
+ 	const struct isx031_reg_list *reg_list;
+ 	int ret;
+ 
+@@ -772,19 +825,31 @@ static int isx031_probe(struct i2c_client *client)
+ 		dev_warn(&client->dev, "no platform data provided\n");
+ 
+ 	isx031->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",
+-						     GPIOD_OUT_HIGH);
++						     GPIOD_OUT_LOW);
++
+ 	if (IS_ERR(isx031->reset_gpio))
+ 		return -EPROBE_DEFER;
+ 	else if (isx031->reset_gpio == NULL)
+ 		dev_warn(&client->dev, "Reset GPIO not found");
+-	else {
++	else
+ 		dev_dbg(&client->dev, "Found reset GPIO");
+-		isx031_reset(isx031->reset_gpio);
+-	}
++
++	info = device_get_match_data(&client->dev);
++	if (info)
++		isx031->is_direct = info->is_direct;
++	else
++		isx031->is_direct = false;
+ 
+ 	/* initialize subdevice */
+ 	sd = &isx031->sd;
+ 	v4l2_i2c_subdev_init(sd, client, &isx031_subdev_ops);
++	if (isx031->is_direct) {
++		ret = isx031_ctrls_init(isx031);
++		if (ret) {
++			dev_err(&client->dev, "failed to init sensor ctrls: %d", ret);
++			return ret;
++		}
++	}
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+ 	sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE | V4L2_SUBDEV_FL_HAS_EVENTS;
+ #else
+@@ -798,9 +863,13 @@ static int isx031_probe(struct i2c_client *client)
+ 	isx031->pad.flags = MEDIA_PAD_FL_SOURCE;
+ 	ret = media_entity_pads_init(&sd->entity, 1, &isx031->pad);
+ 	if (ret < 0) {
+-		dev_err(&client->dev,
+-			"%s : media entity init Failed %d\n", __func__, ret);
+-		return ret;
++		dev_err(&client->dev, "failed to init entity pads: %d", ret);
++		goto probe_error_v4l2_ctrl_handler_free;
++	}
++
++	if (isx031->is_direct) {
++		isx031->sd.state_lock = isx031->sd.ctrl_handler->lock;
++		v4l2_subdev_init_finalize(&isx031->sd);
+ 	}
+ 
+ 	ret = isx031_identify_module(isx031);
+@@ -851,6 +920,9 @@ static int isx031_probe(struct i2c_client *client)
+ 	pm_runtime_disable(&client->dev);
+ 	mutex_destroy(&isx031->mutex);
+ 
++probe_error_v4l2_ctrl_handler_free:
++	v4l2_ctrl_handler_free(isx031->sd.ctrl_handler);
++
+ 	return ret;
+ }
+ 
+@@ -860,13 +932,25 @@ static const struct dev_pm_ops isx031_pm_ops = {
+ 
+ static const struct i2c_device_id isx031_id_table[] = {
+ 	{ "isx031", 0 },
+-	{ /* sentinel */ },
++	{}
+ };
+ MODULE_DEVICE_TABLE(i2c, isx031_id_table);
+ 
++static const struct isx031_info isx031_mipi_info = {
++    .is_direct = true,
++};
++
++static const struct acpi_device_id isx031_acpi_ids[] = {
++	{ "INTC3031", (kernel_ulong_t)&isx031_mipi_info },
++	{}
++};
++
++MODULE_DEVICE_TABLE(acpi, isx031_acpi_ids);
++
+ static struct i2c_driver isx031_i2c_driver = {
+ 	.driver = {
+ 		.name = "isx031",
++		.acpi_match_table = ACPI_PTR(isx031_acpi_ids),
+ 		.pm = &isx031_pm_ops,
+ 	},
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+@@ -880,6 +964,8 @@ static struct i2c_driver isx031_i2c_driver = {
+ 
+ module_i2c_driver(isx031_i2c_driver);
+ 
+-MODULE_AUTHOR("Hao Yao <hao.yao@intel.com>");
+ MODULE_DESCRIPTION("isx031 sensor driver");
++MODULE_AUTHOR("Hao Yao <hao.yao@intel.com>");
++MODULE_AUTHOR("Jonathan Lui <jonathan.ming.jun.lui@intel.com>");
++MODULE_AUTHOR("Wei Khang, Goh <wei.khang1.goh@intel.com>");
+ MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max9x/serdes.c b/drivers/media/i2c/max9x/serdes.c
+index f29949d96aa7..424d0014d68e 100644
+--- a/drivers/media/i2c/max9x/serdes.c
++++ b/drivers/media/i2c/max9x/serdes.c
+@@ -1655,7 +1655,7 @@ static int max9x_registered(struct v4l2_subdev *sd)
+ 						.dev_id = "",
+ 						.table = {
+ 							GPIO_LOOKUP("", 0, "reset",
+-								    GPIO_ACTIVE_HIGH),
++								    GPIO_ACTIVE_LOW),
+ 							{}
+ 						},
+ 					};
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index 4e4f86a1f0b8..def371fe499b 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -91,6 +91,8 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("INTC10C5", 0),
+ 	/* Lontium lt6911uxc */
+ 	IPU_SENSOR_CONFIG("INTC10B1", 0),
++	/* D3 Embedded ISX031 */
++	IPU_SENSOR_CONFIG("INTC3031", 1, 300000000)
+ };
+ 
+ static const struct ipu_sensor_config ipu_supported_sensors_dummy[] = {
+-- 
+2.17.1
+

--- a/kernel_patches/patch_6.12_mainline/0060-media-isx031-ISX031-x2-lanes-couldn-t-stream-after-c.patch
+++ b/kernel_patches/patch_6.12_mainline/0060-media-isx031-ISX031-x2-lanes-couldn-t-stream-after-c.patch
@@ -1,0 +1,133 @@
+From 28bd818d525b517a63ef5cec3a2b2a179a8c91d2 Mon Sep 17 00:00:00 2001
+From: "Goh, Wei Khang1" <wei.khang1.goh@intel.com>
+Date: Thu, 16 Oct 2025 10:45:50 +0800
+Subject: [PATCH 2/3] media: isx031: ISX031 x2 lanes couldn't stream after
+ coming out of S4
+
+It seems that the sensor's registers are reset to it's default values
+only after exiting S4 state. Need to set the appropriate number of lanes
+to allow it to start streaming.
+
+Signed-off-by: Jonathan, Lui <jonathan.ming.jun.lui@intel.com>
+Signed-off-by: Goh, Wei Khang1 <wei.khang1.goh@intel.com>
+---
+ drivers/media/i2c/isx031.c | 63 +++++++++++++++++++++++++++++++++++---
+ 1 file changed, 59 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/i2c/isx031.c b/drivers/media/i2c/isx031.c
+index 8a6f60ccdacb..b5697c738597 100644
+--- a/drivers/media/i2c/isx031.c
++++ b/drivers/media/i2c/isx031.c
+@@ -411,6 +411,51 @@ static void isx031_update_pad_format(const struct isx031_mode *mode,
+ 	fmt->field = V4L2_FIELD_NONE;
+ }
+ 
++static int isx031_lane_sel(struct isx031 *isx031, struct device *dev)
++{
++	struct fwnode_handle *endpoint;
++	struct v4l2_fwnode_endpoint bus_cfg = {
++		.bus_type = V4L2_MBUS_CSI2_DPHY,
++	};
++
++	/* Setting default mode to 4 lanes */
++	int value = 0x17;
++	int ret;
++
++	endpoint =
++		fwnode_graph_get_endpoint_by_id(dev_fwnode(dev), 0, 0,
++						FWNODE_GRAPH_ENDPOINT_NEXT);
++	if (!endpoint) {
++		dev_err(dev, "endpoint node not found");
++		return -EPROBE_DEFER;
++	}
++
++	ret = v4l2_fwnode_endpoint_alloc_parse(endpoint, &bus_cfg);
++	if (ret) {
++		dev_err(dev, "parsing endpoint node failed");
++		goto out_err;
++	}
++
++	/* Check the number of MIPI CSI2 data lanes */
++	if (bus_cfg.bus.mipi_csi2.num_data_lanes != 2 &&
++	    bus_cfg.bus.mipi_csi2.num_data_lanes != 4) {
++		dev_err(dev, "only 2 or 4 data lanes are currently supported");
++		goto out_err;
++	}
++
++	if (2 == bus_cfg.bus.mipi_csi2.num_data_lanes) {
++		value = 0x18;
++	}
++
++	ret = isx031_write_reg(isx031, 0x8A00, ISX031_REG_LEN_08BIT,
++			value);
++
++out_err:
++	v4l2_fwnode_endpoint_free(&bus_cfg);
++	fwnode_handle_put(endpoint);
++	return ret;
++}
++
+ static int isx031_start_streaming(struct isx031 *isx031)
+ {
+ 	int ret;
+@@ -513,10 +558,9 @@ static int __maybe_unused isx031_suspend(struct device *dev)
+ 	if (isx031->streaming)
+ 		isx031_stop_streaming(isx031);
+ 
+-	mutex_unlock(&isx031->mutex);
+-
+ 	/* Active low gpio reset, set 1 to power off sensor */
+ 	gpiod_set_value_cansleep(isx031->reset_gpio, 1);
++	mutex_unlock(&isx031->mutex);
+ 
+ 	return 0;
+ }
+@@ -539,10 +583,11 @@ static int __maybe_unused isx031_resume(struct device *dev)
+ 			ret = gpiod_get_value_cansleep(isx031->reset_gpio);
+ 			usleep_range(200 * 1000, 200 * 1000 + 500);
+ 
+-			if (++count >= 5) {
++			if (++count >= 10) {
+ 				dev_err(&client->dev, "%s: failed to power on reset gpio, reset gpio is %d", __func__, ret);
+ 				break;
+ 			}
++
+ 		} while (ret != 0);
+ 	}
+ 
+@@ -570,6 +615,9 @@ static int __maybe_unused isx031_resume(struct device *dev)
+ 		}
+ 	}
+ 
++	ret = isx031_lane_sel(isx031, &client->dev);
++	if (ret)
++		dev_err(&client->dev, "isx031 mode select failed");
+ 	mutex_unlock(&isx031->mutex);
+ 
+ 	return 0;
+@@ -832,7 +880,7 @@ static int isx031_probe(struct i2c_client *client)
+ 	else if (isx031->reset_gpio == NULL)
+ 		dev_warn(&client->dev, "Reset GPIO not found");
+ 	else
+-		dev_dbg(&client->dev, "Found reset GPIO");
++		dev_info(&client->dev, "Reset GPIO found");
+ 
+ 	info = device_get_match_data(&client->dev);
+ 	if (info)
+@@ -893,6 +941,13 @@ static int isx031_probe(struct i2c_client *client)
+ 		dev_err(&client->dev, "failed to apply preset mode");
+ 		goto probe_error_media_entity_cleanup;
+ 	}
++
++	ret = isx031_lane_sel(isx031, &client->dev);
++	if (ret) {
++		dev_err(&client->dev, "failed to set mode because %d", ret);
++		goto probe_error_media_entity_cleanup;
++	}
++
+ 	isx031->cur_mode = isx031->pre_mode;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
+ 	ret = v4l2_async_register_subdev_sensor_common(&isx031->sd);
+-- 
+2.17.1
+

--- a/kernel_patches/patch_6.12_mainline/0061-media-isx031-pm_runtime_get_sync-returns-Permission-.patch
+++ b/kernel_patches/patch_6.12_mainline/0061-media-isx031-pm_runtime_get_sync-returns-Permission-.patch
@@ -1,0 +1,33 @@
+From 178efcff638845e471d7366f638fecdab8326325 Mon Sep 17 00:00:00 2001
+From: "Goh, Wei Khang1" <wei.khang1.goh@intel.com>
+Date: Thu, 16 Oct 2025 10:52:32 +0800
+Subject: [PATCH 3/3] media: isx031: pm_runtime_get_sync() returns "Permission
+ Denied"
+
+This happened because pm_runtime_disable() is called in the probe
+function before it is even enabled. This causes a negative count.
+Since pm_runtime_enable() is only called for a successful probe,
+pm_runtime_disable() is removed from the error handling path in the
+probe function.
+
+Signed-off-by: Jonathan, Lui <jonathan.ming.jun.lui@intel.com>
+Signed-off-by: Goh, Wei Khang1 <wei.khang1.goh@intel.com>
+---
+ drivers/media/i2c/isx031.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/media/i2c/isx031.c b/drivers/media/i2c/isx031.c
+index b5697c738597..42c1c0110253 100644
+--- a/drivers/media/i2c/isx031.c
++++ b/drivers/media/i2c/isx031.c
+@@ -972,7 +972,6 @@ static int isx031_probe(struct i2c_client *client)
+ 
+ probe_error_media_entity_cleanup:
+ 	media_entity_cleanup(&isx031->sd.entity);
+-	pm_runtime_disable(&client->dev);
+ 	mutex_destroy(&isx031->mutex);
+ 
+ probe_error_v4l2_ctrl_handler_free:
+-- 
+2.17.1
+

--- a/kernel_patches/patch_6.12_mainline/README
+++ b/kernel_patches/patch_6.12_mainline/README
@@ -60,6 +60,9 @@ build kernel driver with community kernel version 6.11 but not iot kernel
        git am 0056-media-i2c-add-support-for-isx031-max9296.patch
        git am 0057-fix-S4-issue-on-TWL.patch
        git am 0058-code-changes-for-link-frequency-and-sensor-physical-.patch
+       git am 0059-media-isx031-Add-support-on-ISX031-MIPI-CSI.patch
+       git am 0060-media-isx031-ISX031-x2-lanes-couldn-t-stream-after-c.patch
+       git am 0061-media-isx031-pm_runtime_get_sync-returns-Permission-.patch
        /*  end   */
 
     c. for USB device need to apply below 2 patches, they are merged to kernel 6.13.


### PR DESCRIPTION
Add ISX031 MIPI CSI support for kernel v6.12.34 Ubuntu 24.04 on RPL, ARL & MTL

media: isx031: Add support on ISX031 MIPI CSI
-isx031: Add support on ISX031 MIPI CSI (D3)
-isx031: Refine is_direct flag for sensor type checking
-isx031: Remove redundant isx031_reset()
-isx031: Add sensor power control for isx031_suspend() & isx031_resume()
media: isx031: ISX031 x2 lanes couldn't stream after coming out of S4
media: isx031: pm_runtime_get_sync() returns "Permission Denied"

Verified sensor driver compatibility with RPL, ARL & MTL kernel 6.12.34
Verified sensor driver compatibility for isx031 mipi direct & gmsl