### PR TITLE
media: i2c: Assign INTC113C HID to ISX031 for upstream compliance

### DIFF
--- a/drivers/media/i2c/isx031.c
+++ b/drivers/media/i2c/isx031.c
@@ -1031,7 +1031,7 @@ static const struct isx031_info isx031_mipi_info = {
 };
 
 static const struct acpi_device_id isx031_acpi_ids[] = {
-	{ "INTC3031", (kernel_ulong_t)&isx031_mipi_info },
+	{ "INTC113C", (kernel_ulong_t)&isx031_mipi_info },
 	{}
 };
 


### PR DESCRIPTION
Allocated INTC113C HID to prepare ISX031 for upstreaming, this ACPI HID is registered for ISX031 GMSL2 and MIPI camera sensors. Current INTC3031 HID used is not officially captured in goto.intel.com/acpi.