### PR TITLE
kernel_patches: patch_6.12_mainline: Add patch files

### DIFF
--- a/kernel_patches/patch_6.12_mainline/0059-media-platform-intel-Add-AR0820-sensor-support-to-IP.patch
+++ b/kernel_patches/patch_6.12_mainline/0059-media-platform-intel-Add-AR0820-sensor-support-to-IP.patch
@@ -1,0 +1,47 @@
+From 66921d91a43ad925ab24b011499ae8392ddfe6cb Mon Sep 17 00:00:00 2001
+From: Izzul Irfan <muhammadx.izzul.irfan.bin.che.iswanizam@intel.com>
+Date: Thu, 18 Dec 2025 16:04:21 +0800
+Subject: [PATCH 1/4] media: platform: intel: Add AR0820 sensor support to IPU
+ ACPI device table
+
+Register the AR0820 sensor in the supported_devices array
+when CONFIG_VIDEO_AR0820 is enabled.
+Add the AR0820 ACPI HID to the ipu_acpi_match table
+for proper device detection.
+Enables platform integration and detection of
+the SENSING AR0820 sensor via ACPI.
+
+Signed-off-by: Tay, Boon Wooi <boonx.wooi.tay@intel.com>
+---
+ drivers/media/platform/intel/ipu-acpi.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/media/platform/intel/ipu-acpi.c b/drivers/media/platform/intel/ipu-acpi.c
+index 8b94dc307735..cc0228d78c8c 100644
+--- a/drivers/media/platform/intel/ipu-acpi.c
++++ b/drivers/media/platform/intel/ipu-acpi.c
+@@ -63,6 +63,10 @@ static const struct ipu_acpi_devices supported_devices[] = {
+ 	{ "INTC031M", ISX031_NAME, get_sensor_pdata, NULL, 0, TYPE_SERDES, "max9x",
+ 		ISX031_I2C_ADDRESS, 1600 },	// D3 ISX031 HID
+ #endif
++#if IS_ENABLED(CONFIG_VIDEO_AR0820)
++	{ "AR0820", AR0820_NAME, get_sensor_pdata, NULL, 0, TYPE_SERDES, "max9296",
++		AR0820_I2C_ADDRESS, 1600 },     // SENSING AR0820 HID
++#endif
+ #endif
+ };
+ 
+@@ -89,6 +93,10 @@ static const struct acpi_device_id ipu_acpi_match[] = {
+ 	{ "INTC1031", 0 },	// ISX031 HID
+ 	{ "INTC031M", 0 },	// D3CMC68N-115-084 ISX031 HID
+ #endif
++#if IS_ENABLED(CONFIG_VIDEO_AR0820)
++	{ "AR0820", 0 },      // AR0820 HID
++#endif
++
+ 	{},
+ };
+ 
+-- 
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0060-media-pci-ipu-bridge-Add-ACPI-HID-for-LI-AR0830-sens.patch
+++ b/kernel_patches/patch_6.12_mainline/0060-media-pci-ipu-bridge-Add-ACPI-HID-for-LI-AR0830-sens.patch
@@ -1,0 +1,34 @@
+From 04cccad4653445755a4b9e64043be38bf7a3a261 Mon Sep 17 00:00:00 2001
+From: Izzul Irfan <muhammadx.izzul.irfan.bin.che.iswanizam@intel.com>
+Date: Wed, 17 Dec 2025 19:07:57 +0800
+Subject: [PATCH 2/4] media: pci: ipu-bridge: Add ACPI HID for LI AR0830 sensor
+
+Register the ACPI Hardware ID (HID) "LIAR0830"
+for the LI AR0830 image sensor in the IPU bridge driver.
+
+Extend the ipu_supported_sensors array to include the LI AR0830 sensor
+with its corresponding HID and configuration.
+This enables proper detection and initialization of the AR0830 sensor via ACPI,
+supporting platforms that use this sensor.
+
+Signed-off-by: Jonathan, Lui <jonathan.ming.jun.lui@intel.com>
+---
+ drivers/media/pci/intel/ipu-bridge.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index 4e4f86a1f0b8..23c2aa5b840d 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -91,6 +91,8 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("INTC10C5", 0),
+ 	/* Lontium lt6911uxc */
+ 	IPU_SENSOR_CONFIG("INTC10B1", 0),
++	/* LI AR0830 */
++	IPU_SENSOR_CONFIG("LIAR0830", 1, 600000000),
+ };
+ 
+ static const struct ipu_sensor_config ipu_supported_sensors_dummy[] = {
+-- 
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0061-media-pci-ipu-bridge-Add-ACPI-ID-for-ISX031-sensor.patch
+++ b/kernel_patches/patch_6.12_mainline/0061-media-pci-ipu-bridge-Add-ACPI-ID-for-ISX031-sensor.patch
@@ -1,0 +1,35 @@
+From 1201bdb7c4c261faa6bdd2b03fec0e2d17327066 Mon Sep 17 00:00:00 2001
+From: Izzul Irfan <muhammadx.izzul.irfan.bin.che.iswanizam@intel.com>
+Date: Wed, 17 Dec 2025 19:16:40 +0800
+Subject: [PATCH 3/4] media: pci: ipu-bridge: Add ACPI ID for ISX031 sensor
+
+Register the ACPI Hardware ID (HID) "INTC113C"
+for the ISX031 sensor in the IPU bridge driver.
+
+Extend the ipu_supported_sensors array to include the ISX031 sensor
+with its corresponding configuration (300 MHz).
+This enables proper detection and initialization of the ISX031 sensor via ACPI,
+supporting platforms that use this sensor.
+
+Signed-off-by: Yew, Chang Ching <chang.ching.yew@intel.com>
+Signed-off-by: Goh, Wei Khang1 <wei.khang1.goh@intel.com>
+---
+ drivers/media/pci/intel/ipu-bridge.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index 23c2aa5b840d..1830d46da575 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -93,6 +93,8 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("INTC10B1", 0),
+ 	/* LI AR0830 */
+ 	IPU_SENSOR_CONFIG("LIAR0830", 1, 600000000),
++	/* ISX031 */
++	IPU_SENSOR_CONFIG("INTC113C", 1, 300000000),
+ };
+ 
+ static const struct ipu_sensor_config ipu_supported_sensors_dummy[] = {
+-- 
+2.34.1
+

--- a/kernel_patches/patch_6.12_mainline/0062-media-i2c-max9x-Add-FSIN-GPIO-support-for-sensor-syn.patch
+++ b/kernel_patches/patch_6.12_mainline/0062-media-i2c-max9x-Add-FSIN-GPIO-support-for-sensor-syn.patch
@@ -1,0 +1,46 @@
+From 8ea780866a4d4ac9d220b5753197e15b77a3622e Mon Sep 17 00:00:00 2001
+From: Izzul Irfan <muhammadx.izzul.irfan.bin.che.iswanizam@intel.com>
+Date: Wed, 17 Dec 2025 19:01:11 +0800
+Subject: [PATCH 4/4] media: i2c: max9x: Add FSIN GPIO support for sensor
+ synchronization
+
+Introduce support for the FSIN (Frame Synchronization Input) GPIO
+in the MAX9x serdes driver.
+
+Add a new GPIO lookup entry for FSIN (GPIO 7) with active low polarity.
+Ensure the FSIN GPIO is registered with the correct chip label,
+similar to the reset GPIO.
+
+This enables external frame synchronization for image sensors,
+improving multi-sensor alignment and timing.
+
+Signed-off-by: Izzul Irfan <muhammadx.izzul.irfan.bin.che.iswanizam@intel.com>
+---
+ drivers/media/i2c/max9x/serdes.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/max9x/serdes.c b/drivers/media/i2c/max9x/serdes.c
+index f29949d96aa7..2f45401b8bf1 100644
+--- a/drivers/media/i2c/max9x/serdes.c
++++ b/drivers/media/i2c/max9x/serdes.c
+@@ -1655,13 +1655,16 @@ static int max9x_registered(struct v4l2_subdev *sd)
+ 						.dev_id = "",
+ 						.table = {
+ 							GPIO_LOOKUP("", 0, "reset",
+-								    GPIO_ACTIVE_HIGH),
++								    GPIO_ACTIVE_LOW),
++							GPIO_LOOKUP("", 7, "fsin",
++								    GPIO_ACTIVE_LOW),
+ 							{}
+ 						},
+ 					};
+ 
+ 					sensor_gpios.dev_id = dev_id;
+ 					sensor_gpios.table[0].key = common->gpio_chip.label;
++					sensor_gpios.table[1].key = common->gpio_chip.label;
+ 
+ 					gpiod_add_lookup_table(&sensor_gpios);
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
 - Added 0059-drivers-media-platform-intel-Add-ACPI-ID-for-Sensing-AR0820.patch to add ACPI ID for Sensing AR0820
 - Added 0060-media-pci-ipu-bridge-Add-ACPI-HID-for-LI-AR0830-sens.patch for AR0830 sensor ACPI integration.
 - Added 0061-media-pci-ipu-bridge-Add-ACPI-ID-for-ISX031-sensor.patch for ISX031 sensor ACPI integration.
 - Added 0062-media-i2c-max9x-Add-FSIN-GPIO-support-for-sensor-syn.patch for FSIN GPIO support.