### PR TITLE
Add IMX471 ACPI HID and link support for BIOS changes

### DIFF
--- a/drivers/media/i2c/imx471.c
+++ b/drivers/media/i2c/imx471.c
@@ -1168,6 +1168,7 @@ static DEFINE_RUNTIME_DEV_PM_OPS(imx471_pm_ops, imx471_suspend, imx471_resume,
 
 static const struct acpi_device_id imx471_acpi_ids[] __maybe_unused = {
 	{ "SONY471A" },
+	{ "TBE20A0"  },
 	{ /* sentinel */ }
 };
 MODULE_DEVICE_TABLE(acpi, imx471_acpi_ids);

--- a/patch/v6.17/0003-media-ipu-bridge-Support-imx471-sensor.patch
+++ b/patch/v6.17/0003-media-ipu-bridge-Support-imx471-sensor.patch
@@ -1,0 +1,14 @@
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index 4e579352ab2c..af0cfa96e735 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -92,6 +92,9 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("OVTI8856", 3, 180000000, 360000000, 720000000),
+ 	/* Toshiba T4KA3 */
+ 	IPU_SENSOR_CONFIG("XMCC0003", 1, 321468000),
++	/* Sony IMX471 */
++	IPU_SENSOR_CONFIG("SONY471A", 1, 200000000),
++	IPU_SENSOR_CONFIG("TBE20A0" , 1, 200000000),
+ };
+ 
+ static const struct ipu_property_names prop_names = {


### PR DESCRIPTION
- Add a new ACPI HID : TBE20A0 for IMX471, because customer changed and identified a new HID in BIOS for IMX471. 
- Add a new ACPI HID and IMX471 link support into IPU-bridge.