### PR TITLE
Add kernel v6.17 patch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Three ways are available:
 3. and build with dkms
 
 ### 1. Build with kernel source tree
-- Tested with kernel v6.10
+- Tested with kernel v6.10 - v6.17
 - Check out kernel
 - Apply patches (please check detail comments below):
 	```sh

--- a/patch/v6.17/0003-media-ipu-bridge-Support-ov05c10-sensor.patch
+++ b/patch/v6.17/0003-media-ipu-bridge-Support-ov05c10-sensor.patch
@@ -1,0 +1,26 @@
+From 4acd8ab400f681b1d58aaf01aa25ea2447ec48c3 Mon Sep 17 00:00:00 2001
+From: Hao Yao <hao.yao@intel.com>
+Date: Thu, 10 Oct 2024 15:13:52 +0800
+Subject: [PATCH 3/5] media: ipu-bridge: Support ov05c10 sensor
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ drivers/media/pci/intel/ipu-bridge.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index 83e682e1a4..6b244377a3 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -75,6 +75,8 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("OVTI02C1", 1, 400000000),
+ 	/* Omnivision OV02E10 */
+ 	IPU_SENSOR_CONFIG("OVTI02E1", 1, 360000000),
++	/* Omnivision ov05c10 */
++	IPU_SENSOR_CONFIG("OVTI05C1", 1, 480000000),
+ 	/* Omnivision OV08A10 */
+ 	IPU_SENSOR_CONFIG("OVTI08A1", 1, 500000000),
+ 	/* Omnivision OV08x40 */
+-- 
+2.43.0
+

--- a/patch/v6.17/in-tree-build/0001-media-ipu6-Workaround-to-build-PSYS.patch
+++ b/patch/v6.17/in-tree-build/0001-media-ipu6-Workaround-to-build-PSYS.patch
@@ -1,0 +1,22 @@
+From f31b776a59026af54c47c22fe952bb7ba0575a75 Mon Sep 17 00:00:00 2001
+From: Dongcheng Yan <dongcheng.yan@intel.com>
+Date: Fri, 13 Sep 2024 18:02:37 +0800
+Subject: [PATCH 1/5] media: ipu6: Workaround to build PSYS
+
+Signed-off-by: Dongcheng Yan <dongcheng.yan@intel.com>
+---
+ drivers/media/pci/intel/ipu6/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/pci/intel/ipu6/Makefile b/drivers/media/pci/intel/ipu6/Makefile
+index a821b0a156..8a4f4cd761 100644
+--- a/drivers/media/pci/intel/ipu6/Makefile
++++ b/drivers/media/pci/intel/ipu6/Makefile
+@@ -21,3 +21,4 @@ intel-ipu6-isys-y		:= ipu6-isys.o \
+ 				ipu6-isys-dwc-phy.o
+ 
+ obj-$(CONFIG_VIDEO_INTEL_IPU6)	+= intel-ipu6-isys.o
++obj-$(CONFIG_VIDEO_INTEL_IPU6)  += psys/
+-- 
+2.43.0
+

--- a/patch/v6.17/in-tree-build/0002-media-i2c-Add-sensors-config.patch
+++ b/patch/v6.17/in-tree-build/0002-media-i2c-Add-sensors-config.patch
@@ -1,0 +1,122 @@
+From 2558df1dce3012c62689818def0f48f844a49814 Mon Sep 17 00:00:00 2001
+From: Hao Yao <hao.yao@intel.com>
+Date: Mon, 25 Mar 2024 14:40:09 +0800
+Subject: [PATCH 2/5] media: i2c: Add sensors config
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ drivers/media/i2c/Kconfig  | 56 ++++++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/Makefile |  6 ++++
+ 2 files changed, 62 insertions(+)
+
+diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
+index e68202954a..3de1f13f9a 100644
+--- a/drivers/media/i2c/Kconfig
++++ b/drivers/media/i2c/Kconfig
+@@ -127,6 +127,33 @@ config VIDEO_HI847
+           To compile this driver as a module, choose M here: the
+           module will be called hi847.
+ 
++config VIDEO_HM11B1
++	tristate "Himax HM11B1 sensor support"
++	help
++	  This is a Video4Linux2 sensor driver for the Himax
++	  HM11B1 camera.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called hm11b1.
++
++config VIDEO_HM2170
++	tristate "Himax HM2170 sensor support"
++	help
++	  This is a Video4Linux2 sensor driver for the Himax
++	  HM2170 camera.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called hm2170.
++
++config VIDEO_HM2172
++	tristate "Himax HM2172 sensor support"
++	help
++	  This is a Video4Linux2 sensor driver for the Himax
++	  HM2172 camera.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called hm2172.
++
+ config VIDEO_IMX208
+ 	tristate "Sony IMX208 sensor support"
+ 	help
+@@ -348,6 +375,15 @@ config VIDEO_OV01A10
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called ov01a10.
+ 
++config VIDEO_OV01A1S
++	tristate "OmniVision OV01A1S sensor support"
++	help
++	  This is a Video4Linux2 sensor driver for the OmniVision
++	  OV01A1S camera.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called ov01a1s.
++
+ config VIDEO_OV02A10
+ 	tristate "OmniVision OV02A10 sensor support"
+ 	help
+@@ -377,6 +413,26 @@ config VIDEO_OV02C10
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called ov02c10.
+ 
++config VIDEO_OV05C10
++	tristate "OmniVision OV05C10 sensor support"
++	depends on ACPI || COMPILE_TEST
++	select V4L2_CCI_I2C
++	help
++	  This is a Video4Linux2 sensor driver for the OmniVision
++	  OV05C10 camera.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called ov05c10.
++
++config VIDEO_OV08A10
++	tristate "OmniVision OV08A10 sensor support"
++	help
++	  This is a Video4Linux2 sensor driver for the OmniVision
++	  OV08A10 camera sensor.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called ov08a10.
++
+ config VIDEO_OV08D10
+         tristate "OmniVision OV08D10 sensor support"
+         help
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index 5873d29433..3a47cab4a8 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -44,6 +44,9 @@ obj-$(CONFIG_VIDEO_GC2145) += gc2145.o
+ obj-$(CONFIG_VIDEO_HI556) += hi556.o
+ obj-$(CONFIG_VIDEO_HI846) += hi846.o
+ obj-$(CONFIG_VIDEO_HI847) += hi847.o
++obj-$(CONFIG_VIDEO_HM11B1) += hm11b1.o
++obj-$(CONFIG_VIDEO_HM2170) += hm2170.o
++obj-$(CONFIG_VIDEO_HM2172) += hm2172.o
+ obj-$(CONFIG_VIDEO_I2C) += video-i2c.o
+ obj-$(CONFIG_VIDEO_IMX208) += imx208.o
+ obj-$(CONFIG_VIDEO_IMX214) += imx214.o
+@@ -82,9 +85,12 @@ obj-$(CONFIG_VIDEO_MT9V032) += mt9v032.o
+ obj-$(CONFIG_VIDEO_MT9V111) += mt9v111.o
+ obj-$(CONFIG_VIDEO_OG01A1B) += og01a1b.o
+ obj-$(CONFIG_VIDEO_OV01A10) += ov01a10.o
++obj-$(CONFIG_VIDEO_OV01A1S) += ov01a1s.o
+ obj-$(CONFIG_VIDEO_OV02A10) += ov02a10.o
+ obj-$(CONFIG_VIDEO_OV02C10) += ov02c10.o
+ obj-$(CONFIG_VIDEO_OV02E10) += ov02e10.o
++obj-$(CONFIG_VIDEO_OV05C10) += ov05c10.o
++obj-$(CONFIG_VIDEO_OV08A10) += ov08a10.o
+ obj-$(CONFIG_VIDEO_OV08D10) += ov08d10.o
+ obj-$(CONFIG_VIDEO_OV08X40) += ov08x40.o
+ obj-$(CONFIG_VIDEO_OV13858) += ov13858.o
+-- 
+2.43.0
+


### PR DESCRIPTION
## Summary

- Add `patch/v6.17/` with kernel patches still needed for 6.17
- Update README tested kernel range to v6.10 - v6.17

## Details

Kernel 6.17 has merged two of the three v6.16 patches, so only one remains:

| Patch | Status in 6.17 |
|-------|---------------|
| 0003 - ipu-bridge: Support ov05c10 sensor | **Not in mainline** — carried forward |
| 0004 - ipu-bridge: Add support for additional link frequencies | Merged — dropped |
| 0005 - ov08x40: Fix the horizontal flip control | Merged — dropped |

The in-tree-build workaround patches (PSYS build + sensor Kconfig) are unchanged from v6.16.

## Test

Out-of-tree DKMS build tested on:
- **Kernel**: 6.17.0-14-generic (Ubuntu 24.04 LTS HWE)
- **Hardware**: Lenovo ThinkPad X1 Carbon Gen 12, Meteor Lake (8086:7d19), OV08F40 sensor
- **Result**: All modules (intel-ipu6-psys + sensor drivers) build and load successfully