### PR TITLE
Properly get frequency in kernel 6.15 and up

### DIFF
--- a/drivers/media/pci/intel/ipu-isys-csi2.c
+++ b/drivers/media/pci/intel/ipu-isys-csi2.c
@@ -102,7 +102,17 @@ int ipu_isys_csi2_get_link_freq(struct ipu_isys_csi2 *csi2, s64 *link_freq)
 	bpp = ipu_isys_mbus_code_to_bpp(csi2->asd.ffmt->code);
 	lanes = csi2->nlanes;
 
-	ret = v4l2_get_link_freq(ext_sd->ctrl_handler, bpp, lanes * 2);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	/*
+	* From kernel 6.15+, v4l2_get_link_freq() supports a pad-based
+	* lookup via struct media_pad *. The IVSC CSI driver dropped its
+	* V4L2_CID_LINK_FREQ control in 6.15, so the old ctrl_handler path
+	* returns -ENOENT. Use the pad instead.
+	*/
+	ret = v4l2_get_link_freq(pipe->external, bpp, lanes * 2);
+#else
+ 	ret = v4l2_get_link_freq(ext_sd->ctrl_handler, bpp, lanes * 2);
+#endif
 	if (ret < 0) {
 		dev_err(dev, "can't get link frequency (%lld)\n", ret);
 		return ret;


### PR DESCRIPTION
From kernel 6.15+, `v4l2_get_link_freq()` supports a pad-based lookup via `struct media_pad *`. The in-kernel MEI CSI driver also dropped its `V4L2_CID_LINK_FREQ` control in 6.15, so the old ctrl_handler path returns `-ENOENT`.
Use the pad instead.

This might help with #423, although not sure if it's a universal fix.

In journalctl I was seeing:

```
intel-ipu6-isys intel-ipu6-isys0: can't get link frequency (-2)
```

The change in MEI CSI driver is in this commit: 
https://github.com/torvalds/linux/commit/56f697e3cdf99e145ca5af0ce84dbb26b8d96c3e on line 572.

Applying this patch and recompiling the driver fixed it for me.

Would really like this patch in upstream, happy to help any way I can.

Tested on 6.8, 6.14, and 6.17.

