### PR TITLE
media: ipu6: Invalidate MMU TLB in dma buffers creation

### DIFF
--- a/drivers/media/pci/intel/ipu6/ipu6-dma.c
+++ b/drivers/media/pci/intel/ipu6/ipu6-dma.c
@@ -206,6 +206,8 @@ void *ipu6_dma_alloc(struct ipu6_bus_device *sys, size_t size,
 		}
 	}
 
+	mmu->tlb_invalidate(mmu);
+
 	info->vaddr = vmap(pages, count, VM_USERMAP, PAGE_KERNEL);
 	if (!info->vaddr)
 		goto out_unmap;


### PR DESCRIPTION
This patch ensures that the MMU TLB is properly invalidated during the creation and mapping of DMA buffers for IPU devices. Without explicit invalidation, stale or incorrect entries in the TLB can cause invalid memory access in hardware.